### PR TITLE
Install NMapsMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,swift,xcode,cocoapods
+
+KCS/Secret.xcconfig

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		591A88812B384E600059E40F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591A88802B384E600059E40F /* ViewController.swift */; };
 		591A88862B384E610059E40F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 591A88852B384E610059E40F /* Assets.xcassets */; };
 		591A88892B384E610059E40F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 591A88872B384E610059E40F /* LaunchScreen.storyboard */; };
+		5986DCE92B390A8D005AE43B /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5986DCE82B390A8D005AE43B /* Secret.xcconfig */; };
 		8FE699E5DAEEDFE5A53D5E82 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
 
@@ -25,6 +26,7 @@
 		591A88852B384E610059E40F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		591A88882B384E610059E40F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		591A888A2B384E610059E40F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5986DCE82B390A8D005AE43B /* Secret.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.debug.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.debug.xcconfig"; sourceTree = "<group>"; };
 		AA9EF30352C847A7C6DEC110 /* Pods-KCS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.release.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.release.xcconfig"; sourceTree = "<group>"; };
 		E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KCS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -45,6 +47,7 @@
 		591A88702B384E600059E40F = {
 			isa = PBXGroup;
 			children = (
+				5986DCE82B390A8D005AE43B /* Secret.xcconfig */,
 				59053D0A2B3889A200D190CC /* .swiftlint.yml */,
 				591A887B2B384E600059E40F /* KCS */,
 				591A887A2B384E600059E40F /* Products */,
@@ -200,6 +203,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5986DCE92B390A8D005AE43B /* Secret.xcconfig in Resources */,
 				59053D0B2B3889A200D190CC /* .swiftlint.yml in Resources */,
 				591A88892B384E610059E40F /* LaunchScreen.storyboard in Resources */,
 				591A88862B384E610059E40F /* Assets.xcassets in Resources */,
@@ -296,6 +300,7 @@
 /* Begin XCBuildConfiguration section */
 		591A888B2B384E610059E40F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5986DCE82B390A8D005AE43B /* Secret.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/KCS/KCS/Application/AppDelegate.swift
+++ b/KCS/KCS/Application/AppDelegate.swift
@@ -6,31 +6,23 @@
 //
 
 import UIKit
+import NMapsMap
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        if let id = Bundle.main.object(forInfoDictionaryKey: "NMAP_CLIENT_ID") as? String {
+            NMFAuthManager.shared().clientId = id
+        }
+        
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
+        
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
 }
-

--- a/KCS/KCS/Resource/Info.plist
+++ b/KCS/KCS/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NMAP_CLIENT_ID</key>
+	<string>$(NMAP_CLIENT_ID)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/KCS/Podfile
+++ b/KCS/Podfile
@@ -11,6 +11,7 @@ target 'KCS' do
   pod 'RxCocoa', '6.6.0'
   pod 'Alamofire'
   pod 'SwiftLint'
+  pod 'NMapsMap'
 
 post_install do |installer|
     installer.pods_project.targets.each do |target|

--- a/KCS/Podfile.lock
+++ b/KCS/Podfile.lock
@@ -1,5 +1,8 @@
 PODS:
   - Alamofire (5.8.1)
+  - NMapsGeometry (1.0.1)
+  - NMapsMap (3.17.0):
+    - NMapsGeometry
   - RxCocoa (6.6.0):
     - RxRelay (= 6.6.0)
     - RxSwift (= 6.6.0)
@@ -10,6 +13,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire
+  - NMapsMap
   - RxCocoa (= 6.6.0)
   - RxSwift (= 6.6.0)
   - SwiftLint
@@ -17,6 +21,8 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
+    - NMapsGeometry
+    - NMapsMap
     - RxCocoa
     - RxRelay
     - RxSwift
@@ -24,11 +30,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
+  NMapsGeometry: 53c573ead66466681cf123f99f698dc8071a4b83
+  NMapsMap: a5b909a31b6f3d27a670f6eb2ddc913c38975474
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
 
-PODFILE CHECKSUM: 2c6299855398049bcf2ff40433cf99d975f3261f
+PODFILE CHECKSUM: 78f2549305fd6b9a6865bb9bf13bcc5e8f5147ad
 
 COCOAPODS: 1.13.0


### PR DESCRIPTION
## ⭐️ Issue Number

- #17

## 🚩 Summary

네이버 지도 SDK를 사용하기 위해 CocoaPods에 NMapsMap을 추가한다.
NMapsMap을 사용하기 위한 설정은 공식 홈페이지를 참고했다. 
[NMapsMap](https://navermaps.github.io/ios-map-sdk/guide-ko/1.html)

## 🛠️ Technical Concerns

### Secret Key 

Naver Map Client ID를 프로젝트에 포함해야 하지만 GitHub에 올렸을 때, 타인이 Client ID를 사용하여 요금이 청구될 수 있다. 
그러므로 GitHub에는 올라가지 않도록 .gitignore에 추가 하여 숨겨야 한다.
전역변수로 설정하는 방법도 있었지만 xcconfig파일과 Info.plist파일을 이용하여 프로젝트 변수로 설정하여 Bundle에서 사용할 수 있도록 설정했다.
참고 : [gitignore로 xcconfig 숨기기](https://ggasoon2.tistory.com/18)

##  ⚠️ To Reviewer 
iOS 프로젝트에 따로 Secret.xcconfig 파일을 추가해주셔야 프로젝트가 정상 작동합니다.

<img width="740" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/c064008a-a605-47ae-8be6-504f19fa7d93">

<img width="247" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/ed8c1efd-2fc4-4d17-b79a-b31b70c5019c">

<img width="792" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/e998b328-adbf-4c45-8a32-12ba95d20961">

위와 같이 파일 추가해주셔야 합니다. `.gitignore`파일은 이미 수정되었으니 수정할 필요 없습니다.
