### PR TITLE
Pod 업데이트

### DIFF
--- a/KCS/Podfile.lock
+++ b/KCS/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - RxRelay (6.6.0):
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
-  - SwiftLint (0.53.0)
+  - SwiftLint (0.54.0)
 
 DEPENDENCIES:
   - Alamofire
@@ -35,7 +35,7 @@ SPEC CHECKSUMS:
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
-  SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
+  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
 PODFILE CHECKSUM: 78f2549305fd6b9a6865bb9bf13bcc5e8f5147ad
 


### PR DESCRIPTION
## ⭐️ Issue Number

- #27

## 🚩 Summary

프로젝트 Xcode상 Wanring을 해결

![Image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/08da9d1d-5f3f-4c55-ae12-19a3bf3dd21a)

CocoaPods에 업데이트할 사항이 있다는 것을 의미한다.

Brew로 CocoaPods를 설치했기 때문에 Brew의 CocoaPods를 먼저 업데이트

<img width="519" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/760edb1c-1240-4d47-9e3f-5749e3749325">

Brew의 CocoaPods 업데이트가 끝나면 프로젝트에 있는 Pods를 업데이트

<img width="821" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/c8997816-07b3-482c-ab82-619ebd4a5852">

Pods가 업데이트 되면서 SwiftLint도 같이 최신 버전으로 업데이트됐다.

## 🛠️ Technical Concerns

### Xcode 고질적 문제

오류를 해결하기 위한 모든 작업 후에도 Xcode의 오류가 사라지지 않았다.

<img width="727" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/2bb4dd78-9adf-4358-94a7-ae4c3a87f4e0">

같은 증상을 가진 사람들의 해결 방법에 따라 Xcode를 완전 종료 후 해결했다.

참고 : [Stack Overflow](https://stackoverflow.com/questions/36788494/how-can-i-get-rid-of-update-to-recommended-settings-warning)

## 🙂 To Reviwer

- 각자 환경에서 Cocoapods를 업데이트 해주셔야 합니다. 
```
brew upgrade cocoapods
```
```
sudo gem install cocoapods -v 1.14.3 # 원하는 version
```
