### PR TITLE
위치 정보 권한 요청 시기 수정

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 기반으로 가게 정보를 제공하기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -456,7 +457,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCS;
+				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCSs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -479,6 +480,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 기반으로 가게 정보를 제공하기 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -489,7 +491,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCS;
+				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCSs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/KCS/KCS/Resource/Info.plist
+++ b/KCS/KCS/Resource/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>사용자의 위치를 기반으로 가게 정보를 제공하기 위해 권한이 필요합니다.</string>
 	<key>NMAP_CLIENT_ID</key>
 	<string>$(NMAP_CLIENT_ID)</string>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## ⭐️ Issue Number

- #35 

## 🚩 Summary

사용자의 위치 권한과 기기 위치 서비스 여부에 따른 권한 요청 플로우 적용

### 앱 실행
1. 사용자가 기기 위치 서비스를 켜지 않고 앱을 실행시킨 경우
  - 무반응
2. 사용자가 기기 위치 서비스를 켜고 앱을 실행시킨 경우
  - 위치 권한을 처음 물어보는 경우, 위치 권한이 `한 번 허용`이었다가 권한이 사라진 경우
    - 위치 권한 요청
  - 위치 권한이 있는 경우
    - 현위치로 카메라 이동(TODO)
  - 위치 권한이 거절된 경우
    - 무반응

### 현 위치 버튼 작동
1. 사용자가 기기 위치 서비스를 켜지 않은 경우
  - 설정으로 이동할 수 있는 UIAlertController를 present
2. 사용자가 기기 위치 서비스를 켜고 앱을 실행시킨 경우
  - 위치 권한이 `한 번 허용`이었다가 권한이 사라진 경우
    - 위치 권한 요청
  - 위치 권한이 있는 경우
    - 현위치로 카메라 이동
  - 위치 권한이 거절된 경우
    - 위치 권한 요청

|위치 권한 요청|기기 위치 서비스 요청|
|--|--|
|![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/9ee5ac42-452a-4170-89c8-7934f7db6b98)|![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/1ccbf5d1-17ea-44f0-9b2f-0d373bcc7055)|


## 🛠️ Technical Concerns

### 삽질: 위치 서비스가 꺼져있는 경우와 위치 위치 권한이 없는 경우
위치 서비스의 권한은 
위치 서비스가 꺼져있는 경우 `CLAuthorizationStatus == .denied`
위치 서비스가 켜져있는 경우
- 위치 권한이 결정되지 않은 경우 : `CLAuthorizationStatus == .notDetermined`
- 위치 권한이 `한 번 허용`, `앱을 사용하는 동안 허용`인 경우 : `CLAuthorizationStatus == .authorizedWhenInUse`
- 위치 권한이 `허용 안 함`인 경우 : `CLAuthorizationStatus == .denied`

이렇게 결정된다.  이때, 위치 서비스가 꺼져있는 경우와 위치 권한이 `허용 안 함`인 경우를 나눠서 사용자에게 권한을 요청하려고 했다.
두 경우 모두 `CLAuthorizationStatus == .denied`였기 때문에 분기처리가 쉽지 않았다.

해결하는 와중에  두 경우가 같은 동작을 하도록 플로우가 수정됐다...

## 📋 To Do

- 현위치로 카메라 이동
