### PR TITLE
현재 위치 재검색 버튼 활성화

### DIFF
--- a/KCS/KCS/Data/Network/NetworkURL.swift
+++ b/KCS/KCS/Data/Network/NetworkURL.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum NetworkURL {
-    
-    static let storeURL = "http://3.35.49.129:8080/api/v1/storecertification/byLocation"
+
+    static let storeURL = "http://13.124.127.77:8080/api/v1/storecertification/byLocation"
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -174,7 +174,7 @@ private extension HomeViewController {
                     let marker = Marker(type: lastType, position: location)
                     marker.mapView = self.mapView.mapView
                     self.markers.append(marker)
-                    refreshButton.isHidden = true
+                    self.refreshButton.isHidden = true
                 }
             }
             .disposed(by: disposeBag)

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -274,6 +274,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
         if reason == NMFMapChangedByGesture {
             locationButton.setImage(UIImage.locationButtonNone, for: .normal)
         }
+        refreshButton.isHidden = false
     }
     
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -18,11 +18,6 @@ final class HomeViewController: UIViewController {
     private lazy var goodPriceFilterButton: FilterButton = {
         let button = FilterButton(title: "착한 가격 업소", color: UIColor.goodPrice)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.rx.tap
-            .bind { [weak self] in
-                self?.refreshButton.isHidden = false
-            }
-            .disposed(by: disposeBag)
         
         return button
     }()
@@ -30,11 +25,6 @@ final class HomeViewController: UIViewController {
     private lazy var exemplaryFilterButton: FilterButton = {
         let button = FilterButton(title: "모범 음식점", color: UIColor.exemplary)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.rx.tap
-            .bind { [weak self] in
-                self?.refreshButton.isHidden = false
-            }
-            .disposed(by: disposeBag)
         
         return button
     }()
@@ -42,11 +32,6 @@ final class HomeViewController: UIViewController {
     private lazy var safeFilterButton: FilterButton = {
         let button = FilterButton(title: "안심 식당", color: UIColor.safe)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.rx.tap
-            .bind { [weak self] in
-                self?.refreshButton.isHidden = false
-            }
-            .disposed(by: disposeBag)
         
         return button
     }()

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -133,6 +133,7 @@ final class HomeViewController: UIViewController {
                     ),
                     types: getActivatedTypes()
                 )
+                button.isHidden = true
             }
             .disposed(by: self.disposeBag)
         

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -15,21 +15,21 @@ final class HomeViewController: UIViewController {
     
     private let disposeBag = DisposeBag()
     
-    private lazy var goodPriceFilterButton: FilterButton = {
+    private let goodPriceFilterButton: FilterButton = {
         let button = FilterButton(title: "착한 가격 업소", color: UIColor.goodPrice)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
     }()
     
-    private lazy var exemplaryFilterButton: FilterButton = {
+    private let exemplaryFilterButton: FilterButton = {
         let button = FilterButton(title: "모범 음식점", color: UIColor.exemplary)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
     }()
     
-    private lazy var safeFilterButton: FilterButton = {
+    private let safeFilterButton: FilterButton = {
         let button = FilterButton(title: "안심 식당", color: UIColor.safe)
         button.translatesAutoresizingMaskIntoConstraints = false
         

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -133,7 +133,6 @@ final class HomeViewController: UIViewController {
                     ),
                     types: getActivatedTypes()
                 )
-                button.isHidden = true
             }
             .disposed(by: self.disposeBag)
         
@@ -175,6 +174,7 @@ private extension HomeViewController {
                     let marker = Marker(type: lastType, position: location)
                     marker.mapView = self.mapView.mapView
                     self.markers.append(marker)
+                    refreshButton.isHidden = true
                 }
             }
             .disposed(by: disposeBag)

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -18,20 +18,35 @@ final class HomeViewController: UIViewController {
     private lazy var goodPriceFilterButton: FilterButton = {
         let button = FilterButton(title: "착한 가격 업소", color: UIColor.goodPrice)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.rx.tap
+            .bind { [weak self] in
+                self?.refreshButton.isHidden = false
+            }
+            .disposed(by: disposeBag)
         
         return button
     }()
     
-    private let exemplaryFilterButton: FilterButton = {
+    private lazy var exemplaryFilterButton: FilterButton = {
         let button = FilterButton(title: "모범 음식점", color: UIColor.exemplary)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.rx.tap
+            .bind { [weak self] in
+                self?.refreshButton.isHidden = false
+            }
+            .disposed(by: disposeBag)
         
         return button
     }()
     
-    private let safeFilterButton: FilterButton = {
+    private lazy var safeFilterButton: FilterButton = {
         let button = FilterButton(title: "안심 식당", color: UIColor.safe)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.rx.tap
+            .bind { [weak self] in
+                self?.refreshButton.isHidden = false
+            }
+            .disposed(by: disposeBag)
         
         return button
     }()
@@ -167,6 +182,7 @@ private extension HomeViewController {
         viewModel.refreshComplete
             .bind { [weak self] loadedStores in
                 guard let self = self else { return }
+                self.refreshButton.isHidden = true
                 self.markers.forEach { $0.mapView = nil }
                 loadedStores.stores.forEach {
                     let location = $0.location.toMapLocation()
@@ -174,7 +190,6 @@ private extension HomeViewController {
                     let marker = Marker(type: lastType, position: location)
                     marker.mapView = self.mapView.mapView
                     self.markers.append(marker)
-                    self.refreshButton.isHidden = true
                 }
             }
             .disposed(by: disposeBag)
@@ -192,7 +207,9 @@ private extension HomeViewController {
         if safeFilterButton.isSelected {
             types.append(.safe)
         }
-        
+        if types.isEmpty {
+            return [.goodPrice, .exemplary, .safe]
+        }
         return types
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -210,6 +210,7 @@ private extension HomeViewController {
         if types.isEmpty {
             return [.goodPrice, .exemplary, .safe]
         }
+        
         return types
     }
     
@@ -298,6 +299,19 @@ extension HomeViewController: NMFMapViewCameraDelegate {
         if reason == NMFMapChangedByDeveloper {
             mapView.positionMode = .direction
             locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
+            let startPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: 0))
+            let endPoint = mapView.projection.latlng(from: CGPoint(x: view.frame.width, y: view.frame.height))
+            viewModel.refresh(
+                northWestLocation: Location(
+                    longitude: startPoint.lng,
+                    latitude: startPoint.lat
+                ),
+                southEastLocation: Location(
+                    longitude: endPoint.lng,
+                    latitude: endPoint.lat
+                ),
+                types: getActivatedTypes()
+            )
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -34,9 +34,14 @@ final class HomeViewModelImpl: HomeViewModel {
         types: [CertificationType] = [.goodPrice, .exemplary, .safe]
     ) {
         fetchStoresUseCase.execute(northWestLocation: northWestLocation, southEastLocation: southEastLocation)
-            .subscribe(onNext: { [weak self] _ in
-                self?.applyFilter(types: types)
-            })
+            .subscribe(
+                onNext: { [weak self] _ in
+                    self?.applyFilter(types: types)
+                },
+                onError: { error in
+                    dump(error)
+                }
+            )
             .disposed(by: disposeBag)
     }
     


### PR DESCRIPTION
## ⭐️ Issue Number

- #58

## 🚩 Summary

- 현 지도에서 검색 버튼 활성화 로직 적용
- 앱 시작시 자신의 위치로 카메라 변경 후 마커 표시

## 🛠️ Technical Concerns

### ViewModel과 ViewController의 책임

ViewController에 있어야 할 코드와 ViewModel에 있어야 할 코드는 무슨 기준으로 나눠야 할까?
ViewModel은 추상화된 View로 UI 요소가 포함되면 안된다.
```swift
let startPoint = mapView.mapView.projection.latlng(from: CGPoint(x: 0, y: 0))
let endPoint = mapView.mapView.projection.latlng(from: CGPoint(x: view.frame.width, y: view.frame.height))
viewModel.refresh(
    northWestLocation: Location(
        longitude: startPoint.lng,
        latitude: startPoint.lat
    ),
    southEastLocation: Location(
        longitude: endPoint.lng,
        latitude: endPoint.lat
    ),
    types: getActivatedTypes()
)
```
해당 코드가 ViewController 단에 존재한다. 
refresh에 인자로 넣어줄 코드를 개발자가 직접 넣어줘야하는 불편함이 있다.
이를 ViewModel에 책임을 이동시키려 시도했으나 VieModel에서 view.frame에 접근할 수 없기 때문에 실패했다.
추후에 zoom과 관련하여 재검색에 들어갈 로직을 리팩토링해야할 것 같다.

## 📋 To Do

- Refresh 버튼 리팩토링
