### PR TITLE
URL을 통한 사진 다운로드

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		5977BE8D2B5966F900725C90 /* StoreRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE8C2B5966F900725C90 /* StoreRepositoryImplTests.swift */; };
 		5977BE942B59738800725C90 /* FetchStoresUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE932B59738800725C90 /* FetchStoresUseCase.swift */; };
 		5977BE982B5999E000725C90 /* FetchStoresUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE972B5999E000725C90 /* FetchStoresUseCaseImpl.swift */; };
+		5977BE9A2B59AC3300725C90 /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE992B59AC3300725C90 /* ImageRepository.swift */; };
+		5977BE9C2B59AC8D00725C90 /* ImageRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE9B2B59AC8D00725C90 /* ImageRepositoryImpl.swift */; };
+		5977BE9E2B59ACE800725C90 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE9D2B59ACE800725C90 /* ImageCache.swift */; };
 		59C306A42B4D7EBA00862625 /* Marker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306A32B4D7EBA00862625 /* Marker.swift */; };
 		59C306A62B4D966C00862625 /* CertificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306A52B4D966C00862625 /* CertificationType.swift */; };
 		59C306A92B4FF9AF00862625 /* StoreRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306A82B4FF9AF00862625 /* StoreRepository.swift */; };
@@ -42,6 +45,7 @@
 		59C306CF2B50399C00862625 /* RequestLocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306CE2B50399C00862625 /* RequestLocationDTO.swift */; };
 		59C306D82B50650D00862625 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306D72B50650D00862625 /* Encodable+.swift */; };
 		59C306DC2B506F3D00862625 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306DB2B506F3D00862625 /* NetworkError.swift */; };
+		59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478B02B59BB00002FEF9E /* ImageRepositoryError.swift */; };
 		8FE699E5DAEEDFE5A53D5E82 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */; };
 		A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A802D1F52B5277620091FDE7 /* CertificationLabel.swift */; };
 		A89087042B4E7F3500767225 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087032B4E7F3500767225 /* FilterButton.swift */; };
@@ -93,6 +97,9 @@
 		5977BE8C2B5966F900725C90 /* StoreRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreRepositoryImplTests.swift; sourceTree = "<group>"; };
 		5977BE932B59738800725C90 /* FetchStoresUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoresUseCase.swift; sourceTree = "<group>"; };
 		5977BE972B5999E000725C90 /* FetchStoresUseCaseImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchStoresUseCaseImpl.swift; sourceTree = "<group>"; };
+		5977BE992B59AC3300725C90 /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
+		5977BE9B2B59AC8D00725C90 /* ImageRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryImpl.swift; sourceTree = "<group>"; };
+		5977BE9D2B59ACE800725C90 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		5986DCE82B390A8D005AE43B /* Secret.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		59C306A32B4D7EBA00862625 /* Marker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Marker.swift; sourceTree = "<group>"; };
 		59C306A52B4D966C00862625 /* CertificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificationType.swift; sourceTree = "<group>"; };
@@ -113,6 +120,7 @@
 		59C306CE2B50399C00862625 /* RequestLocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocationDTO.swift; sourceTree = "<group>"; };
 		59C306D72B50650D00862625 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		59C306DB2B506F3D00862625 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		59F478B02B59BB00002FEF9E /* ImageRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryError.swift; sourceTree = "<group>"; };
 		5FF0FF2386EEB69182D6EA4C /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 		9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.debug.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.debug.xcconfig"; sourceTree = "<group>"; };
 		A802D1F52B5277620091FDE7 /* CertificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificationLabel.swift; sourceTree = "<group>"; };
@@ -256,6 +264,7 @@
 			children = (
 				A8ACB7CD2B54ED6400540BD1 /* Repository */,
 				59C306AE2B4FFE3700862625 /* Network */,
+				5977BE9D2B59ACE800725C90 /* ImageCache.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -313,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				59C306A82B4FF9AF00862625 /* StoreRepository.swift */,
+				5977BE992B59AC3300725C90 /* ImageRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -411,6 +421,7 @@
 			children = (
 				A8ACB7D62B57BE4E00540BD1 /* Error */,
 				59C306B12B50001F00862625 /* StoreRepositoryImpl.swift */,
+				5977BE9B2B59AC8D00725C90 /* ImageRepositoryImpl.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -419,6 +430,7 @@
 			isa = PBXGroup;
 			children = (
 				A8ACB7D72B57BE7D00540BD1 /* StoreRepoError.swift */,
+				59F478B02B59BB00002FEF9E /* ImageRepositoryError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -673,9 +685,11 @@
 				5977BE612B55374000725C90 /* HomeViewModel.swift in Sources */,
 				59C306A62B4D966C00862625 /* CertificationType.swift in Sources */,
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
+				59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */,
 				59C306C92B501B9D00862625 /* RegularOpeningHours.swift in Sources */,
 				59C306BF2B50109100862625 /* Location.swift in Sources */,
 				591A88812B384E600059E40F /* HomeViewController.swift in Sources */,
+				5977BE9C2B59AC8D00725C90 /* ImageRepositoryImpl.swift in Sources */,
 				A8ACB7ED2B59647400540BD1 /* OpeningHourError.swift in Sources */,
 				A8ACB7D52B57BAD200540BD1 /* GetStoreInfoUseCase.swift in Sources */,
 				5977BE742B57FA7A00725C90 /* FilteredStores.swift in Sources */,
@@ -685,6 +699,7 @@
 				A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */,
 				59C306CD2B5035B100862625 /* StoreAPI.swift in Sources */,
 				A8ACB7DB2B58B51A00540BD1 /* Date+.swift in Sources */,
+				5977BE9E2B59ACE800725C90 /* ImageCache.swift in Sources */,
 				59C306A42B4D7EBA00862625 /* Marker.swift in Sources */,
 				5977BE662B553BA800725C90 /* HomeViewModelImpl.swift in Sources */,
 				5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */,
@@ -702,6 +717,7 @@
 				5977BE942B59738800725C90 /* FetchStoresUseCase.swift in Sources */,
 				59C306BB2B5003F500862625 /* NetworkURL.swift in Sources */,
 				59C306B22B50001F00862625 /* StoreRepositoryImpl.swift in Sources */,
+				5977BE9A2B59AC3300725C90 /* ImageRepository.swift in Sources */,
 				591A887D2B384E600059E40F /* AppDelegate.swift in Sources */,
 				59C306DC2B506F3D00862625 /* NetworkError.swift in Sources */,
 				59C306C32B50114100862625 /* Day.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		59C306D82B50650D00862625 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306D72B50650D00862625 /* Encodable+.swift */; };
 		59C306DC2B506F3D00862625 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C306DB2B506F3D00862625 /* NetworkError.swift */; };
 		59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478B02B59BB00002FEF9E /* ImageRepositoryError.swift */; };
+		59F478B32B59BDD6002FEF9E /* FetchImageUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478B22B59BDD6002FEF9E /* FetchImageUseCaseImpl.swift */; };
+		59F478B52B59BE0B002FEF9E /* FetchImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478B42B59BE0B002FEF9E /* FetchImageUseCase.swift */; };
 		8FE699E5DAEEDFE5A53D5E82 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */; };
 		A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A802D1F52B5277620091FDE7 /* CertificationLabel.swift */; };
 		A89087042B4E7F3500767225 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087032B4E7F3500767225 /* FilterButton.swift */; };
@@ -121,6 +123,8 @@
 		59C306D72B50650D00862625 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		59C306DB2B506F3D00862625 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		59F478B02B59BB00002FEF9E /* ImageRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryError.swift; sourceTree = "<group>"; };
+		59F478B22B59BDD6002FEF9E /* FetchImageUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchImageUseCaseImpl.swift; sourceTree = "<group>"; };
+		59F478B42B59BE0B002FEF9E /* FetchImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchImageUseCase.swift; sourceTree = "<group>"; };
 		5FF0FF2386EEB69182D6EA4C /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 		9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.debug.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.debug.xcconfig"; sourceTree = "<group>"; };
 		A802D1F52B5277620091FDE7 /* CertificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificationLabel.swift; sourceTree = "<group>"; };
@@ -204,6 +208,7 @@
 				5977BE932B59738800725C90 /* FetchStoresUseCase.swift */,
 				A8ACB7D42B57BAD200540BD1 /* GetStoreInfoUseCase.swift */,
 				A8ACB7E72B595A2100540BD1 /* GetOpenClosedUseCase.swift */,
+				59F478B42B59BE0B002FEF9E /* FetchImageUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -216,6 +221,7 @@
 				5977BE972B5999E000725C90 /* FetchStoresUseCaseImpl.swift */,
 				A8ACB7D22B57BA8E00540BD1 /* GetStoreInfoUseCaseImpl.swift */,
 				A8ACB7E92B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift */,
+				59F478B22B59BDD6002FEF9E /* FetchImageUseCaseImpl.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -687,9 +693,11 @@
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
 				59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */,
 				59C306C92B501B9D00862625 /* RegularOpeningHours.swift in Sources */,
+				59F478B52B59BE0B002FEF9E /* FetchImageUseCase.swift in Sources */,
 				59C306BF2B50109100862625 /* Location.swift in Sources */,
 				591A88812B384E600059E40F /* HomeViewController.swift in Sources */,
 				5977BE9C2B59AC8D00725C90 /* ImageRepositoryImpl.swift in Sources */,
+				59F478B32B59BDD6002FEF9E /* FetchImageUseCaseImpl.swift in Sources */,
 				A8ACB7ED2B59647400540BD1 /* OpeningHourError.swift in Sources */,
 				A8ACB7D52B57BAD200540BD1 /* GetStoreInfoUseCase.swift in Sources */,
 				5977BE742B57FA7A00725C90 /* FilteredStores.swift in Sources */,

--- a/KCS/KCS/Data/ImageCache.swift
+++ b/KCS/KCS/Data/ImageCache.swift
@@ -1,0 +1,27 @@
+//
+//  ImageCache.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import Foundation
+
+final class ImageCache {
+    
+    static let shared = ImageCache()
+    private let cache = NSCache<NSURL, NSData>()
+    
+    func getImageData(for key: NSURL) -> NSData? {
+        if let cachedImageData = cache.object(forKey: key as NSURL) {
+            return cachedImageData
+        }
+        
+        return nil
+    }
+    
+    func setImageData(_ data: NSData, for key: NSURL) {
+        cache.setObject(data, forKey: key as NSURL)
+    }
+
+}

--- a/KCS/KCS/Data/Network/DTO/StoreDTO.swift
+++ b/KCS/KCS/Data/Network/DTO/StoreDTO.swift
@@ -62,7 +62,8 @@ struct StoreDTO: Codable {
             address: formattedAddress,
             phoneNumber: phoneNumber,
             location: location.toEntity(),
-            openingHour: openingHours
+            openingHour: openingHours,
+            localPhotos: localPhotos
         )
     }
     

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -11,32 +11,38 @@ import Alamofire
 enum StoreAPI {
     
     case getStores(location: RequestLocationDTO)
+    case getImage(url: String)
     
 }
 
 extension StoreAPI: Router, URLRequestConvertible {
 
     public var baseURL: String {
-        return NetworkURL.storeURL
+        switch self {
+        case .getStores:
+            return NetworkURL.storeURL
+        case .getImage(let url):
+            return url
+        }
     }
     
     public var path: String {
         switch self {
-        case .getStores:
+        case .getStores, .getImage:
             return ""
         }
     }
     
     public var method: HTTPMethod {
         switch self {
-        case .getStores:
+        case .getStores, .getImage:
             return .get
         }
     }
     
     public var headers: [String: String] {
         switch self {
-        case .getStores:
+        case .getStores, .getImage:
             return [
                 "Content-Type": "application/json"
             ]
@@ -48,7 +54,8 @@ extension StoreAPI: Router, URLRequestConvertible {
             switch self {
             case let .getStores(location):
                 return try location.asDictionary()
-                
+            case .getImage:
+                return nil
             }
         } catch let error {
             dump(error)
@@ -62,6 +69,8 @@ extension StoreAPI: Router, URLRequestConvertible {
         switch self {
         case .getStores:
             return URLEncoding.default
+        case .getImage:
+            return nil
         }
     }
     

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -42,10 +42,12 @@ extension StoreAPI: Router, URLRequestConvertible {
     
     public var headers: [String: String] {
         switch self {
-        case .getStores, .getImage:
+        case .getStores:
             return [
                 "Content-Type": "application/json"
             ]
+        case .getImage:
+            return [:]
         }
     }
     

--- a/KCS/KCS/Data/Repository/Error/ImageRepositoryError.swift
+++ b/KCS/KCS/Data/Repository/Error/ImageRepositoryError.swift
@@ -1,0 +1,20 @@
+//
+//  ImageRepositoryError.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import Foundation
+
+enum ImageRepositoryError: Error, LocalizedError {
+    
+    case noImageData
+    
+    var errorDescription: String {
+        switch self {
+        case .noImageData:
+            return "ImageData가 없습니다."
+        }
+    }
+}

--- a/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
@@ -1,0 +1,38 @@
+//
+//  ImageRepositoryImpl.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import RxSwift
+import Alamofire
+
+final class ImageRepositoryImpl: ImageRepository {
+    
+    func fetchImage(
+        url: String
+    ) -> Observable<Data> {
+        return Observable<Data>.create { observer -> Disposable in
+            if let imageURL = URL(string: url) {
+                if let imageData = ImageCache.shared.getImageData(for: imageURL as NSURL) {
+                    observer.onNext(Data(imageData))
+                } else {
+                    AF.request(StoreAPI.getImage(url: url))
+                        .responseDecodable(of: Data.self) { response in
+                            switch response.result {
+                            case .success(let result):
+                                ImageCache.shared.setImageData(result as NSData, for: imageURL as NSURL)
+                                observer.onNext(result)
+                            case .failure(let error):
+                                observer.onError(error)
+                            }
+                        }
+                }
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
@@ -19,15 +19,19 @@ final class ImageRepositoryImpl: ImageRepository {
                     observer.onNext(Data(imageData))
                 } else {
                     AF.request(StoreAPI.getImage(url: url))
-                        .responseDecodable(of: Data.self) { response in
+                        .response(completionHandler: { response in
                             switch response.result {
                             case .success(let result):
-                                ImageCache.shared.setImageData(result as NSData, for: imageURL as NSURL)
-                                observer.onNext(result)
+                                if let resultData = result {
+                                    ImageCache.shared.setImageData(resultData as NSData, for: imageURL as NSURL)
+                                    observer.onNext(resultData)
+                                } else {
+                                    observer.onError(ImageRepositoryError.noImageData)
+                                }
                             case .failure(let error):
                                 observer.onError(error)
                             }
-                        }
+                        })
                 }
             }
             

--- a/KCS/KCS/Domain/Entity/Store.swift
+++ b/KCS/KCS/Domain/Entity/Store.swift
@@ -17,6 +17,7 @@ struct Store: Hashable {
     let phoneNumber: String?
     let location: Location
     let openingHour: [RegularOpeningHours]
+    let localPhotos: [String]
     
     static func == (lhs: Store, rhs: Store) -> Bool {
         return lhs.id == rhs.id

--- a/KCS/KCS/Domain/Interface/Repository/ImageRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/ImageRepository.swift
@@ -1,0 +1,16 @@
+//
+//  ImageRepository.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import RxSwift
+
+protocol ImageRepository {
+    
+    func fetchImage(
+        url: String
+    ) -> Observable<Data>
+    
+}

--- a/KCS/KCS/Domain/Interface/UseCase/FetchImageUseCase.swift
+++ b/KCS/KCS/Domain/Interface/UseCase/FetchImageUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  FetchImageUseCase.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import RxSwift
+
+protocol FetchImageUseCase {
+    
+    var repository: ImageRepository { get }
+    
+    init(repository: ImageRepository)
+    
+    func execute(url: String) -> Observable<Data>
+    
+}

--- a/KCS/KCS/Domain/UseCase/FetchImageUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/FetchImageUseCaseImpl.swift
@@ -1,0 +1,19 @@
+//
+//  FetchImageUseCaseImpl.swift
+//  KCS
+//
+//  Created by 조성민 on 1/19/24.
+//
+
+import RxSwift
+
+struct FetchImageUseCaseImpl: FetchImageUseCase {
+    
+    let repository: ImageRepository
+    
+    func execute(url: String) -> Observable<Data> {
+        return repository.fetchImage(url: url)
+    }
+    
+}
+

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -139,7 +139,10 @@ final class HomeViewController: UIViewController {
     }()
     
     private lazy var summaryInformationView: SummaryInformationView = {
-        let viewModel = SummaryInformationViewModelImpl(getOpenClosedUseCase: GetOpenClosedUseCaseImpl())
+        let viewModel = SummaryInformationViewModelImpl(
+            getOpenClosedUseCase: GetOpenClosedUseCaseImpl(),
+            fetchImageUseCase: FetchImageUseCaseImpl(repository: ImageRepositoryImpl())
+        )
         let view = SummaryInformationView(viewModel: viewModel)
         view.translatesAutoresizingMaskIntoConstraints = false
         

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -72,6 +72,8 @@ final class SummaryInformationView: UIView {
     private let storeImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.setLayerCorner(cornerRadius: 6)
+        imageView.clipsToBounds = true
         
         return imageView
     }()

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -108,6 +108,7 @@ final class SummaryInformationView: UIView {
         setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         addUIComponents()
         configureConstraints()
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -116,6 +117,14 @@ final class SummaryInformationView: UIView {
 }
 
 private extension SummaryInformationView {
+    
+    func bind() {
+        viewModel.setThumbnailImage
+            .subscribe(onNext: { [weak self] data in
+                self?.storeImageView.image = UIImage(data: data)
+            })
+            .disposed(by: disposeBag)
+    }
     
     func setBackgroundColor() {
         backgroundColor = .white
@@ -203,6 +212,9 @@ extension SummaryInformationView {
                     self?.callButtonTapped(phoneNum: phoneNum)
                 }
                 .disposed(by: disposeBag)
+        }
+        if let thumbnailURL = store.localPhotos.first {
+            viewModel.setThumbnailImage(url: thumbnailURL)
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
@@ -10,14 +10,19 @@ import RxRelay
 
 final class SummaryInformationViewModelImpl: SummaryInformationViewModel {
     
-    let getOpenClosedUseCase: GetOpenClosedUseCase
+    private let disposeBag = DisposeBag()
     
-    init(getOpenClosedUseCase: GetOpenClosedUseCase) {
+    let getOpenClosedUseCase: GetOpenClosedUseCase
+    let fetchImageUseCase: FetchImageUseCase
+    
+    init(getOpenClosedUseCase: GetOpenClosedUseCase, fetchImageUseCase: FetchImageUseCase) {
         self.getOpenClosedUseCase = getOpenClosedUseCase
+        self.fetchImageUseCase = fetchImageUseCase
     }
     
     var getOpenClosed = PublishRelay<OpenClosedType>()
     var getOpeningHour = PublishRelay<String>()
+    var setThumbnailImage = PublishRelay<Data>()
     
     func isOpenClosed(
         openingHour: [RegularOpeningHours]
@@ -29,6 +34,19 @@ final class SummaryInformationViewModelImpl: SummaryInformationViewModel {
         openingHour: [RegularOpeningHours]
     ) {
         getOpeningHour.accept(openingHourString(openingHour: openingHour))
+    }
+    
+    func setThumbnailImage(url: String) {
+        fetchImageUseCase.execute(url: url)
+            .subscribe(
+                onNext: { [weak self] imageData in
+                    self?.setThumbnailImage.accept(imageData)
+                },
+                onError: { error in
+                    print(error.localizedDescription)
+                }
+            )
+            .disposed(by: disposeBag)
     }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
@@ -11,6 +11,7 @@ import RxRelay
 protocol SummaryInformationViewModel: SummaryInformationViewModelInput, SummaryInformationViewModelOutput {
     
     var getOpenClosedUseCase: GetOpenClosedUseCase { get }
+    var fetchImageUseCase: FetchImageUseCase { get }
     
 }
 
@@ -24,11 +25,16 @@ protocol SummaryInformationViewModelInput {
         openingHour: [RegularOpeningHours]
     )
     
+    func setThumbnailImage(
+        url: String
+    )
+    
 }
 
 protocol SummaryInformationViewModelOutput {
     
     var getOpeningHour: PublishRelay<String> { get }
     var getOpenClosed: PublishRelay<OpenClosedType> { get }
+    var setThumbnailImage: PublishRelay<Data> { get }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #67

## 🚩 Summary

- URL을 통한 사진 API 통신
- FetchImageUseCase 구현
- ImageRepository 구현
- ImageCache 구현
- SummaryInformationView storeImageView에 binding 

## 🛠️ Technical Concerns

### Fetch UseCase
Fetch하는 UseCase는 로직이 없는 것이 대부분이다.
이를 재사용성을 위해 레이어를 나눠 UseCase로 작성하는 것이 올바른 것인지 점점 의문이 생긴다.
ViewModel에서 Repository를 받아 직접 fetch하여 사용하고 싶은 마음이 굴뚝같지만 아키텍처를 준수하기 위해서 UseCase를 작성했다.

### 싱글톤 이미지 캐시

이미지 캐시 객체를 싱글톤으로 했다. 
어느 뷰에서든 한 번 통신한 이미지는 저장되어 다시 통신하지 않아도 되도록 구현했다.

## 📋 To Do

- SummaryInformationView의 Input Output 네이밍과 역할이 명확하지 않아서 수정이 필요하다.
- ViewModel의 Input Output 패턴을 수정할 필요가 있다. (action 함수와 enum 활용)
