### PR TITLE
ViewModel input 구조 변경

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -231,7 +231,7 @@ private extension HomeViewController {
     
     func bind() {
         
-        viewModel.refreshComplete
+        viewModel.refreshOutput
             .bind { [weak self] filteredStores in
                 guard let self = self else { return }
                 self.refreshButton.isHidden = true
@@ -246,7 +246,7 @@ private extension HomeViewController {
             }
             .disposed(by: disposeBag)
         
-        viewModel.getStoreInfoComplete
+        viewModel.getStoreInfoOutput
             .bind { [weak self] store in
                 guard let self = self else { return }
                 markerClicked()

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -27,7 +27,7 @@ final class HomeViewController: UIViewController {
                 } else {
                     activatedFilter.append(.goodPrice)
                 }
-                viewModel.fetchFilteredStores(filters: getActivatedTypes())
+                viewModel.action(input: .fetchFilteredStores(filters: getActivatedTypes()))
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
@@ -48,7 +48,7 @@ final class HomeViewController: UIViewController {
                 } else {
                     activatedFilter.append(.exemplary)
                 }
-                viewModel.fetchFilteredStores(filters: getActivatedTypes())
+                viewModel.action(input: .fetchFilteredStores(filters: getActivatedTypes()))
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
@@ -69,7 +69,7 @@ final class HomeViewController: UIViewController {
                 } else {
                     activatedFilter.append(.safe)
                 }
-                viewModel.fetchFilteredStores(filters: getActivatedTypes())
+                viewModel.action(input: .fetchFilteredStores(filters: getActivatedTypes()))
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
@@ -122,7 +122,7 @@ final class HomeViewController: UIViewController {
     
     private var markers: [Marker] = []
     private var clickedMarker: Marker?
-
+    
     private lazy var mapView: NMFNaverMapView = {
         let map = NMFNaverMapView()
         map.translatesAutoresizingMaskIntoConstraints = false
@@ -149,11 +149,11 @@ final class HomeViewController: UIViewController {
         return view
     }()
     
-    private lazy var locationBottomConstraint = locationButton.bottomAnchor.constraint(equalTo: summaryInformationView.topAnchor, 
+    private lazy var locationBottomConstraint = locationButton.bottomAnchor.constraint(equalTo: summaryInformationView.topAnchor,
                                                                                        constant: -29)
-    private lazy var refreshBottomConstraint = refreshButton.bottomAnchor.constraint(equalTo: summaryInformationView.topAnchor, 
+    private lazy var refreshBottomConstraint = refreshButton.bottomAnchor.constraint(equalTo: summaryInformationView.topAnchor,
                                                                                      constant: -29)
-    private lazy var summaryInfoBottomConstraint = summaryInformationView.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, 
+    private lazy var summaryInfoBottomConstraint = summaryInformationView.bottomAnchor.constraint(equalTo: mapView.bottomAnchor,
                                                                                                   constant: 224)
     
     private let requestLocationServiceAlert: UIAlertController = {
@@ -184,16 +184,18 @@ final class HomeViewController: UIViewController {
                 guard let self = self else { return }
                 let startPoint = mapView.mapView.projection.latlng(from: CGPoint(x: 0, y: 0))
                 let endPoint = mapView.mapView.projection.latlng(from: CGPoint(x: view.frame.width, y: view.frame.height))
-                viewModel.refresh(
-                    northWestLocation: Location(
-                        longitude: startPoint.lng,
-                        latitude: startPoint.lat
-                    ),
-                    southEastLocation: Location(
-                        longitude: endPoint.lng,
-                        latitude: endPoint.lat
-                    ),
-                    filters: getActivatedTypes()
+                viewModel.action(
+                    input: .refresh(
+                        northWestLocation: Location(
+                            longitude: startPoint.lng,
+                            latitude: startPoint.lat
+                        ),
+                        southEastLocation: Location(
+                            longitude: endPoint.lng,
+                            latitude: endPoint.lat
+                        ),
+                        filters: getActivatedTypes()
+                    )
                 )
             }
             .disposed(by: self.disposeBag)
@@ -282,11 +284,7 @@ private extension HomeViewController {
             }
             marker.isSelected.toggle()
             if marker.isSelected {
-                do {
-                    try viewModel.markerTapped(tag: marker.tag)
-                } catch {
-                    dump(error)
-                }
+                viewModel.action(input: .markerTapped(tag: marker.tag))
             }
             clickedMarker = marker
             
@@ -407,16 +405,18 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
             let startPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: 0))
             let endPoint = mapView.projection.latlng(from: CGPoint(x: view.frame.width, y: view.frame.height))
-            viewModel.refresh(
-                northWestLocation: Location(
-                    longitude: startPoint.lng,
-                    latitude: startPoint.lat
-                ),
-                southEastLocation: Location(
-                    longitude: endPoint.lng,
-                    latitude: endPoint.lat
-                ),
-                filters: getActivatedTypes()
+            viewModel.action(
+                input: .refresh(
+                    northWestLocation: Location(
+                        longitude: startPoint.lng,
+                        latitude: startPoint.lat
+                    ),
+                    southEastLocation: Location(
+                        longitude: endPoint.lng,
+                        latitude: endPoint.lat
+                    ),
+                    filters: getActivatedTypes()
+                )
             )
         }
     }

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -198,8 +198,8 @@ extension SummaryInformationView {
     func setUIContents(store: Store) {
         storeTitle.text = store.title
         categoty.text = store.category
-        viewModel.setOpenClosed(openingHour: store.openingHour)
-        viewModel.setOpeningHour(openingHour: store.openingHour)
+        viewModel.action(input: .setOpenClosed(openingHour: store.openingHour))
+        viewModel.action(input: .setOpeningHour(openingHour: store.openingHour))
         removeStackView()
         store.certificationTypes
             .map({
@@ -216,7 +216,7 @@ extension SummaryInformationView {
                 .disposed(by: disposeBag)
         }
         if let thumbnailURL = store.localPhotos.first {
-            viewModel.fetchThumbnailImage(url: thumbnailURL)
+            viewModel.action(input: .fetchThumbnailImage(url: thumbnailURL))
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -46,7 +46,7 @@ final class SummaryInformationView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 15)
         label.textColor = UIColor.goodPrice
-        viewModel.getOpenClosed
+        viewModel.openClosedOutput
             .bind { [weak self] openClosedType in
                 label.text = openClosedType.rawValue
             }
@@ -60,7 +60,7 @@ final class SummaryInformationView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 13)
         label.textColor = UIColor.kcsGray
-        viewModel.getOpeningHour
+        viewModel.openingHourOutput
             .bind { [weak self] text in
                 label.text = text
             }
@@ -121,7 +121,7 @@ final class SummaryInformationView: UIView {
 private extension SummaryInformationView {
     
     func bind() {
-        viewModel.setThumbnailImage
+        viewModel.thumbnailImageOutput
             .subscribe(onNext: { [weak self] data in
                 self?.storeImageView.image = UIImage(data: data)
             })
@@ -198,8 +198,8 @@ extension SummaryInformationView {
     func setUIContents(store: Store) {
         storeTitle.text = store.title
         categoty.text = store.category
-        viewModel.isOpenClosed(openingHour: store.openingHour)
-        viewModel.getOpeningHour(openingHour: store.openingHour)
+        viewModel.setOpenClosed(openingHour: store.openingHour)
+        viewModel.setOpeningHour(openingHour: store.openingHour)
         removeStackView()
         store.certificationTypes
             .map({
@@ -216,7 +216,7 @@ extension SummaryInformationView {
                 .disposed(by: disposeBag)
         }
         if let thumbnailURL = store.localPhotos.first {
-            viewModel.setThumbnailImage(url: thumbnailURL)
+            viewModel.fetchThumbnailImage(url: thumbnailURL)
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -33,6 +33,29 @@ final class HomeViewModelImpl: HomeViewModel {
         self.getStoreInfoUseCase = getStoreInfoUseCase
     }
     
+    func action(input: HomeViewModelInputCase) {
+        do {
+            switch input {
+            case .refresh(let northWestLocation, let southEastLocation, let filters):
+                refresh(
+                    northWestLocation: northWestLocation,
+                    southEastLocation: southEastLocation,
+                    filters: filters
+                )
+            case .fetchFilteredStores(let filters):
+                fetchFilteredStores(filters: filters)
+            case .markerTapped(let tag):
+                try markerTapped(tag: tag)
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+}
+
+private extension HomeViewModelImpl {
+    
     func refresh(
         northWestLocation: Location,
         southEastLocation: Location,

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -16,8 +16,8 @@ final class HomeViewModelImpl: HomeViewModel {
     
     private let disposeBag = DisposeBag()
     
-    var getStoreInfoComplete = PublishRelay<Store>()
-    var refreshComplete = PublishRelay<[FilteredStores]>()
+    var getStoreInfoOutput = PublishRelay<Store>()
+    var refreshOutput = PublishRelay<[FilteredStores]>()
     
     let dependency: HomeDependency
     
@@ -109,11 +109,11 @@ private extension HomeViewModelImpl {
                 }
             }
         }
-        refreshComplete.accept([goodPriceStores, exemplaryStores, safeStores])
+        refreshOutput.accept([goodPriceStores, exemplaryStores, safeStores])
     }
     
     func markerTapped(tag: UInt) throws {
-        getStoreInfoComplete.accept(
+        getStoreInfoOutput.accept(
             try getStoreInfoUseCase.execute(tag: tag)
         )
     }

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
@@ -20,27 +20,27 @@ final class SummaryInformationViewModelImpl: SummaryInformationViewModel {
         self.fetchImageUseCase = fetchImageUseCase
     }
     
-    var getOpenClosed = PublishRelay<OpenClosedType>()
-    var getOpeningHour = PublishRelay<String>()
-    var setThumbnailImage = PublishRelay<Data>()
+    var openClosedOutput = PublishRelay<OpenClosedType>()
+    var openingHourOutput = PublishRelay<String>()
+    var thumbnailImageOutput = PublishRelay<Data>()
     
-    func isOpenClosed(
+    func setOpenClosed(
         openingHour: [RegularOpeningHours]
     ) {
-        getOpenClosed.accept(getOpenClosedUseCase.execute(openingHours: openingHour))
+        openClosedOutput.accept(getOpenClosedUseCase.execute(openingHours: openingHour))
     }
     
-    func getOpeningHour(
+    func setOpeningHour(
         openingHour: [RegularOpeningHours]
     ) {
-        getOpeningHour.accept(openingHourString(openingHour: openingHour))
+        openingHourOutput.accept(openingHourString(openingHour: openingHour))
     }
     
-    func setThumbnailImage(url: String) {
+    func fetchThumbnailImage(url: String) {
         fetchImageUseCase.execute(url: url)
             .subscribe(
                 onNext: { [weak self] imageData in
-                    self?.setThumbnailImage.accept(imageData)
+                    self?.thumbnailImageOutput.accept(imageData)
                 },
                 onError: { error in
                     print(error.localizedDescription)

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
@@ -15,14 +15,29 @@ final class SummaryInformationViewModelImpl: SummaryInformationViewModel {
     let getOpenClosedUseCase: GetOpenClosedUseCase
     let fetchImageUseCase: FetchImageUseCase
     
+    var openClosedOutput = PublishRelay<OpenClosedType>()
+    var openingHourOutput = PublishRelay<String>()
+    var thumbnailImageOutput = PublishRelay<Data>()
+    
     init(getOpenClosedUseCase: GetOpenClosedUseCase, fetchImageUseCase: FetchImageUseCase) {
         self.getOpenClosedUseCase = getOpenClosedUseCase
         self.fetchImageUseCase = fetchImageUseCase
     }
     
-    var openClosedOutput = PublishRelay<OpenClosedType>()
-    var openingHourOutput = PublishRelay<String>()
-    var thumbnailImageOutput = PublishRelay<Data>()
+    func action(input: SummaryInformationViewInputCase) {
+        switch input {
+        case .setOpenClosed(let openingHour):
+            setOpenClosed(openingHour: openingHour)
+        case .setOpeningHour(let openingHour):
+            setOpeningHour(openingHour: openingHour)
+        case .fetchThumbnailImage(let url):
+            fetchThumbnailImage(url: url)
+        }
+    }
+    
+}
+
+private extension SummaryInformationViewModelImpl {
     
     func setOpenClosed(
         openingHour: [RegularOpeningHours]

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -48,7 +48,7 @@ protocol HomeViewModelInput {
 
 protocol HomeViewModelOutput {
     
-    var getStoreInfoComplete: PublishRelay<Store> { get }
-    var refreshComplete: PublishRelay<[FilteredStores]> { get }
+    var getStoreInfoOutput: PublishRelay<Store> { get }
+    var refreshOutput: PublishRelay<[FilteredStores]> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -24,15 +24,26 @@ protocol HomeViewModel: HomeViewModelInput, HomeViewModelOutput {
     
 }
 
-protocol HomeViewModelInput {
+enum HomeViewModelInputCase {
     
-    func refresh(
+    case refresh(
         northWestLocation: Location,
         southEastLocation: Location,
         filters: [CertificationType]
-    ) 
-    func fetchFilteredStores(filters: [CertificationType])
-    func markerTapped(tag: UInt) throws
+    )
+    case fetchFilteredStores(
+        filters: [CertificationType]
+    )
+    case markerTapped(
+        tag: UInt
+    )
+    
+}
+
+protocol HomeViewModelInput {
+    
+    func action(input: HomeViewModelInputCase)
+    
 }
 
 protocol HomeViewModelOutput {

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
@@ -15,19 +15,23 @@ protocol SummaryInformationViewModel: SummaryInformationViewModelInput, SummaryI
     
 }
 
-protocol SummaryInformationViewModelInput {
+enum SummaryInformationViewInputCase {
     
-    func setOpenClosed(
+    case setOpenClosed(
         openingHour: [RegularOpeningHours]
     )
-    
-    func setOpeningHour(
+    case setOpeningHour(
         openingHour: [RegularOpeningHours]
     )
-    
-    func fetchThumbnailImage(
+    case fetchThumbnailImage(
         url: String
     )
+    
+}
+
+protocol SummaryInformationViewModelInput {
+    
+    func action(input: SummaryInformationViewInputCase)
     
 }
 

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
@@ -17,15 +17,15 @@ protocol SummaryInformationViewModel: SummaryInformationViewModelInput, SummaryI
 
 protocol SummaryInformationViewModelInput {
     
-    func isOpenClosed(
+    func setOpenClosed(
         openingHour: [RegularOpeningHours]
     )
     
-    func getOpeningHour(
+    func setOpeningHour(
         openingHour: [RegularOpeningHours]
     )
     
-    func setThumbnailImage(
+    func fetchThumbnailImage(
         url: String
     )
     
@@ -33,8 +33,8 @@ protocol SummaryInformationViewModelInput {
 
 protocol SummaryInformationViewModelOutput {
     
-    var getOpeningHour: PublishRelay<String> { get }
-    var getOpenClosed: PublishRelay<OpenClosedType> { get }
-    var setThumbnailImage: PublishRelay<Data> { get }
+    var openingHourOutput: PublishRelay<String> { get }
+    var openClosedOutput: PublishRelay<OpenClosedType> { get }
+    var thumbnailImageOutput: PublishRelay<Data> { get }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #69

## 🚩 Summary

- ViewModel 통일성 개선
- ViewModel 단방향성 구조로 수정

기존의 ViewModel 구조는 바깥에서 안 쪽으로 들어오는 방향은 단 방향이 맞지만 들어오는 방향이 여러 방향이었다.
input이 여러 방향에서 들어올 수 있는 구조였다.
<개선 전>
```swift
protocol HomeViewModelInput {
    
    // 매개변수 생략
    func refresh() 
    func fetchFilteredStores()
    func markerTapped() throws

}

protocol HomeViewModelOutput {
    
    //제네릭 생략
    var getStoreInfoComplete: PublishRelay<> { get }
    var refreshComplete: PublishRelay<> { get }
    
}

```

들어오는 방향을 하나로 통일하여 단방향 구조를 개선했다.
<개선 후>
```swift
enum HomeViewModelInputCase {
    
    // 매개변수 생략
    case refresh()
    case fetchFilteredStores()
    case markerTapped()
    
}

protocol HomeViewModelInput {
    
    func action(input: HomeViewModelInputCase)
    
}

protocol HomeViewModelOutput {
    
    //제네릭 생략
    var getStoreInfoComplete: PublishRelay<> { get }
    var refreshComplete: PublishRelay<> { get }
    
}

```

## 🛠️ Technical Concerns

### ViewModel 단방향성

ViewModel 데이터 플로우 방향이 안쪽으로만 향하면 되는 줄 알았다. 
하지만 밖에서 들어오는 input도 하나의 입구로 만들어줘야 단방향성이 완성된다.
action이라는 함수와 enum을 이용하여 단방향성을 준수했다.
