### PR TITLE
마커 선택시 맨 앞으로 나오도록 구현

### DIFF
--- a/KCS/KCS/Presentation/Home/View/Marker.swift
+++ b/KCS/KCS/Presentation/Home/View/Marker.swift
@@ -43,7 +43,7 @@ private extension Marker {
             case .safe:
                 icon = NMFOverlayImage(image: UIImage.markerSafeSelected)
             }
-            self.globalZIndex = 300000
+            self.globalZIndex = 250000
         } else {
             switch type {
             case .goodPrice:

--- a/KCS/KCS/Presentation/Home/View/Marker.swift
+++ b/KCS/KCS/Presentation/Home/View/Marker.swift
@@ -16,7 +16,7 @@ final class Marker: NMFMarker {
             setUI(type: certificationType)
         }
     }
-    
+    private lazy var unselectedGlobalZIndex: Int = self.globalZIndex
     private let certificationType: CertificationType
 
     init(certificationType: CertificationType, position: NMGLatLng? = nil) {
@@ -43,6 +43,7 @@ private extension Marker {
             case .safe:
                 icon = NMFOverlayImage(image: UIImage.markerSafeSelected)
             }
+            self.globalZIndex = 300000
         } else {
             switch type {
             case .goodPrice:
@@ -52,6 +53,7 @@ private extension Marker {
             case .safe:
                 icon = NMFOverlayImage(image: UIImage.markerSafeNormal)
             }
+            self.globalZIndex = unselectedGlobalZIndex
         }
         self.iconImage = icon
     }


### PR DESCRIPTION
## ⭐️ Issue Number

- #94

## 🚩 Summary

- 마커 선택시 오버레이 높이 상단으로 이동
- 마커 해제시 원래의 오버레이 높이로 이동

![Simulator Screen Recording - iPhone 15 Pro - 2024-01-22 at 05 02 42](https://github.com/Korea-Certified-Store/iOS/assets/128480641/3f1f7b25-5691-40f1-810d-df6e390f75e5)
