### PR TITLE
요약 정보 카드 UIView로 수정

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -914,7 +914,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -972,7 +972,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1000,7 +1000,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1035,7 +1035,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1063,7 +1063,7 @@
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCSUnitTest;
@@ -1088,7 +1088,7 @@
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = KoreaCertifiedStore.KCSUnitTest;

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		A8ACB7DB2B58B51A00540BD1 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DA2B58B51A00540BD1 /* Date+.swift */; };
 		A8ACB7DD2B58E3DE00540BD1 /* OpenClosedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DC2B58E3DE00540BD1 /* OpenClosedType.swift */; };
 		A8ACB7DF2B594F4B00540BD1 /* SummaryInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */; };
-		A8ACB7E22B594F7400540BD1 /* StoreInformationViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E12B594F7400540BD1 /* StoreInformationViewModelImpl.swift */; };
+		A8ACB7E22B594F7400540BD1 /* SummaryInformationViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E12B594F7400540BD1 /* SummaryInformationViewModelImpl.swift */; };
 		A8ACB7E82B595A2100540BD1 /* GetOpenClosedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E72B595A2100540BD1 /* GetOpenClosedUseCase.swift */; };
 		A8ACB7EA2B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E92B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift */; };
 		A8ACB7ED2B59647400540BD1 /* OpeningHourError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */; };
@@ -174,7 +174,7 @@
 		A8ACB7DA2B58B51A00540BD1 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		A8ACB7DC2B58E3DE00540BD1 /* OpenClosedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClosedType.swift; sourceTree = "<group>"; };
 		A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInformationViewModel.swift; sourceTree = "<group>"; };
-		A8ACB7E12B594F7400540BD1 /* StoreInformationViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationViewModelImpl.swift; sourceTree = "<group>"; };
+		A8ACB7E12B594F7400540BD1 /* SummaryInformationViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInformationViewModelImpl.swift; sourceTree = "<group>"; };
 		A8ACB7E72B595A2100540BD1 /* GetOpenClosedUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetOpenClosedUseCase.swift; sourceTree = "<group>"; };
 		A8ACB7E92B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetOpenClosedUseCaseImpl.swift; sourceTree = "<group>"; };
 		A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHourError.swift; sourceTree = "<group>"; };
@@ -270,7 +270,7 @@
 				A8ACB7E02B594F5F00540BD1 /* protocol */,
 				5977BE652B553BA800725C90 /* HomeViewModelImpl.swift */,
 				5977BE672B553C8300725C90 /* HomeDependency.swift */,
-				A8ACB7E12B594F7400540BD1 /* StoreInformationViewModelImpl.swift */,
+				A8ACB7E12B594F7400540BD1 /* SummaryInformationViewModelImpl.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -795,7 +795,7 @@
 				5977BE662B553BA800725C90 /* HomeViewModelImpl.swift in Sources */,
 				A81EFBB32B5BC57800D0C0D7 /* OpenClosedContent.swift in Sources */,
 				5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */,
-				A8ACB7E22B594F7400540BD1 /* StoreInformationViewModelImpl.swift in Sources */,
+				A8ACB7E22B594F7400540BD1 /* SummaryInformationViewModelImpl.swift in Sources */,
 				59C306CF2B50399C00862625 /* RequestLocationDTO.swift in Sources */,
 				A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */,
 				A8ACB7D82B57BE7D00540BD1 /* StoreRepositoryError.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -68,14 +68,15 @@
 		A81EFBC72B5D597400D0C0D7 /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A81EFBBE2B5D597400D0C0D7 /* Pretendard-Bold.ttf */; };
 		A81EFBC82B5D597400D0C0D7 /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */; };
 		A81EFBCA2B5D5A2300D0C0D7 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */; };
+		A81EFBD42B6019FD00D0C0D7 /* StoreInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBD32B6019FD00D0C0D7 /* StoreInformationView.swift */; };
 		A89087042B4E7F3500767225 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087032B4E7F3500767225 /* FilterButton.swift */; };
 		A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087092B4EF00B00767225 /* SystemImage.swift */; };
 		A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870C2B4EF91600767225 /* UIView+SetLayer.swift */; };
-		A890870F2B4F836C00767225 /* StoreInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870E2B4F836C00767225 /* StoreInformationViewController.swift */; };
+		A890870F2B4F836C00767225 /* SummaryInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870E2B4F836C00767225 /* SummaryInformationView.swift */; };
 		A8ACB7D82B57BE7D00540BD1 /* StoreRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7D72B57BE7D00540BD1 /* StoreRepositoryError.swift */; };
 		A8ACB7DB2B58B51A00540BD1 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DA2B58B51A00540BD1 /* Date+.swift */; };
 		A8ACB7DD2B58E3DE00540BD1 /* OpenClosedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DC2B58E3DE00540BD1 /* OpenClosedType.swift */; };
-		A8ACB7DF2B594F4B00540BD1 /* StoreInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DE2B594F4B00540BD1 /* StoreInformationViewModel.swift */; };
+		A8ACB7DF2B594F4B00540BD1 /* SummaryInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */; };
 		A8ACB7E22B594F7400540BD1 /* StoreInformationViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E12B594F7400540BD1 /* StoreInformationViewModelImpl.swift */; };
 		A8ACB7E82B595A2100540BD1 /* GetOpenClosedUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E72B595A2100540BD1 /* GetOpenClosedUseCase.swift */; };
 		A8ACB7EA2B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7E92B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift */; };
@@ -164,14 +165,15 @@
 		A81EFBBE2B5D597400D0C0D7 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		A81EFBD32B6019FD00D0C0D7 /* StoreInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationView.swift; sourceTree = "<group>"; };
 		A89087032B4E7F3500767225 /* FilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterButton.swift; sourceTree = "<group>"; };
 		A89087092B4EF00B00767225 /* SystemImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImage.swift; sourceTree = "<group>"; };
 		A890870C2B4EF91600767225 /* UIView+SetLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SetLayer.swift"; sourceTree = "<group>"; };
-		A890870E2B4F836C00767225 /* StoreInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationViewController.swift; sourceTree = "<group>"; };
+		A890870E2B4F836C00767225 /* SummaryInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInformationView.swift; sourceTree = "<group>"; };
 		A8ACB7D72B57BE7D00540BD1 /* StoreRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreRepositoryError.swift; sourceTree = "<group>"; };
 		A8ACB7DA2B58B51A00540BD1 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		A8ACB7DC2B58E3DE00540BD1 /* OpenClosedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClosedType.swift; sourceTree = "<group>"; };
-		A8ACB7DE2B594F4B00540BD1 /* StoreInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationViewModel.swift; sourceTree = "<group>"; };
+		A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryInformationViewModel.swift; sourceTree = "<group>"; };
 		A8ACB7E12B594F7400540BD1 /* StoreInformationViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationViewModelImpl.swift; sourceTree = "<group>"; };
 		A8ACB7E72B595A2100540BD1 /* GetOpenClosedUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetOpenClosedUseCase.swift; sourceTree = "<group>"; };
 		A8ACB7E92B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetOpenClosedUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -357,11 +359,12 @@
 			isa = PBXGroup;
 			children = (
 				591A88802B384E600059E40F /* HomeViewController.swift */,
-				A890870E2B4F836C00767225 /* StoreInformationViewController.swift */,
+				A890870E2B4F836C00767225 /* SummaryInformationView.swift */,
 				59C306A32B4D7EBA00862625 /* Marker.swift */,
 				A89087032B4E7F3500767225 /* FilterButton.swift */,
 				A802D1F52B5277620091FDE7 /* CertificationLabel.swift */,
 				5977BE572B5524D500725C90 /* RefreshButton.swift */,
+				A81EFBD32B6019FD00D0C0D7 /* StoreInformationView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -515,7 +518,7 @@
 			isa = PBXGroup;
 			children = (
 				5977BE602B55374000725C90 /* HomeViewModel.swift */,
-				A8ACB7DE2B594F4B00540BD1 /* StoreInformationViewModel.swift */,
+				A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */,
 			);
 			path = protocol;
 			sourceTree = "<group>";
@@ -766,7 +769,7 @@
 			files = (
 				A81EFBB52B5D477600D0C0D7 /* UILabel+.swift in Sources */,
 				59C306A62B4D966C00862625 /* CertificationType.swift in Sources */,
-				A890870F2B4F836C00767225 /* StoreInformationViewController.swift in Sources */,
+				A890870F2B4F836C00767225 /* SummaryInformationView.swift in Sources */,
 				A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */,
 				5977BE612B55374000725C90 /* HomeViewModel.swift in Sources */,
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
@@ -788,6 +791,7 @@
 				A81EFBCA2B5D5A2300D0C0D7 /* UIFont+.swift in Sources */,
 				5977BE9E2B59ACE800725C90 /* ImageCache.swift in Sources */,
 				59C306A42B4D7EBA00862625 /* Marker.swift in Sources */,
+				A81EFBD42B6019FD00D0C0D7 /* StoreInformationView.swift in Sources */,
 				5977BE662B553BA800725C90 /* HomeViewModelImpl.swift in Sources */,
 				A81EFBB32B5BC57800D0C0D7 /* OpenClosedContent.swift in Sources */,
 				5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */,
@@ -811,7 +815,7 @@
 				59C306AD2B4FFAC700862625 /* StoreDTO.swift in Sources */,
 				59C306A92B4FF9AF00862625 /* StoreRepository.swift in Sources */,
 				5977BE982B5999E000725C90 /* FetchStoresUseCaseImpl.swift in Sources */,
-				A8ACB7DF2B594F4B00540BD1 /* StoreInformationViewModel.swift in Sources */,
+				A8ACB7DF2B594F4B00540BD1 /* SummaryInformationViewModel.swift in Sources */,
 				A8ACB7F12B5AEBE300540BD1 /* GetStoreInformationUseCase.swift in Sources */,
 				591A887F2B384E600059E40F /* SceneDelegate.swift in Sources */,
 				A8ACB7EF2B5AEBB900540BD1 /* GetStoreInformationUseCaseImpl.swift in Sources */,

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -24,7 +24,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             fetchStoresUseCase: FetchStoresUseCaseImpl(repository: repository),
             getStoreInformationUseCase: GetStoreInformationUseCaseImpl(repository: repository)
         )
-        window?.rootViewController = HomeViewController(viewModel: viewModel)
+        let summaryInformationViewModel = SummaryInformationViewModelImpl(
+            getOpenClosedUseCase: GetOpenClosedUseCaseImpl(),
+            fetchImageUseCase: FetchImageUseCaseImpl(repository: ImageRepositoryImpl())
+        )
+        window?.rootViewController = HomeViewController(viewModel: viewModel, summaryInformationViewModel: summaryInformationViewModel)
         window?.makeKeyAndVisible()
     }
 

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -173,7 +173,7 @@ final class HomeViewController: UIViewController {
     
     private var activatedFilter: [CertificationType] = []
     
-    private var storeInformationViewController: StoreInformationViewController?
+    private var storeInformationViewController: SummaryInformationView?
     
     private let dismissObserver = PublishRelay<Void>()
     
@@ -303,7 +303,7 @@ private extension HomeViewController {
             fetchImageUseCase: FetchImageUseCaseImpl(repository: ImageRepositoryImpl())
         )
         let contentHeightObserver = PublishRelay<CGFloat>()
-        storeInformationViewController = StoreInformationViewController(
+        storeInformationViewController = SummaryInformationView(
             viewModel: storeViewModel,
             contentHeightObserver: contentHeightObserver,
             dismissObserver: dismissObserver

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -239,9 +239,8 @@ private extension HomeViewController {
         
         summaryInformationHeightObserver.bind { [weak self] height in
             self?.storeInformationOriginalHeight = height
-            self?.locationButtonBottomConstraint.constant = -16
-            self?.refreshButtonBottomConstraint.constant = -16
-            self?.setNewConstraints(storeInformationHeight: height)
+            self?.setBottomConstraints(constraint: -16)
+            self?.setHeightConstraint(height: height)
         }
         .disposed(by: disposeBag)
     }
@@ -311,13 +310,17 @@ private extension HomeViewController {
     func storeInformationViewDismiss() {
         clickedMarker?.isSelected = false
         clickedMarker = nil
-        locationButtonBottomConstraint.constant = -37
-        refreshButtonBottomConstraint.constant = -37
-        setNewConstraints(storeInformationHeight: 0)
+        setBottomConstraints(constraint: -37)
+        setHeightConstraint(height: 0)
     }
     
-    func setNewConstraints(storeInformationHeight: CGFloat) {
-        storeInformationHeightConstraint.constant = storeInformationHeight
+    func setBottomConstraints(constraint: CGFloat) {
+        locationButtonBottomConstraint.constant = constraint
+        refreshButtonBottomConstraint.constant = constraint
+    }
+    
+    func setHeightConstraint(height: CGFloat) {
+        storeInformationHeightConstraint.constant = height
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.view.layoutIfNeeded()
         }
@@ -339,19 +342,18 @@ private extension HomeViewController {
         }
         if recognizer.state == .ended {
             if storeInformationHeightConstraint.constant > 420 {
-                setNewConstraints(storeInformationHeight: 600)
+                setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
+                setHeightConstraint(height: 600)
             } else {
-                setNewConstraints(storeInformationHeight: storeInformationOriginalHeight)
+                setHeightConstraint(height: storeInformationOriginalHeight)
             }
         }
         if recognizer.state == .changed {
             if storeInformationHeightConstraint.constant > 420 {
                 // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
-                locationButtonBottomConstraint.constant = storeInformationHeightConstraint.constant - 441
-                refreshButtonBottomConstraint.constant = storeInformationHeightConstraint.constant - 441
+                setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
             } else {
-                locationButtonBottomConstraint.constant = -16
-                refreshButtonBottomConstraint.constant = -16
+                setBottomConstraints(constraint: -16)
             }
         }
         

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -287,13 +287,9 @@ private extension HomeViewController {
                 if clickedMarker == marker { return true }
                 if clickedMarker.isSelected {
                     self?.storeInformationViewDismiss()
-                    self?.markerSelected(marker: marker)
-                } else {
-                    self?.markerSelected(marker: marker)
                 }
-            } else {
-                self?.markerSelected(marker: marker)
             }
+            self?.markerSelected(marker: marker)
             
             return true
         }
@@ -340,21 +336,24 @@ private extension HomeViewController {
         if height > 230 && height < 620 {
             storeInformationHeightConstraint.constant = height
         }
-        if recognizer.state == .changed {
+        
+        switch recognizer.state {
+        case .changed:
             if storeInformationHeightConstraint.constant > 420 {
                 // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
                 setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
             } else {
                 setBottomConstraints(constraint: -16)
             }
-        }
-        if recognizer.state == .ended {
+        case .ended:
             if storeInformationHeightConstraint.constant > 420 {
                 setBottomConstraints(constraint: 600 - 441)
                 setHeightConstraint(height: 600)
             } else {
                 setHeightConstraint(height: storeInformationOriginalHeight)
             }
+        default:
+            return
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -340,14 +340,6 @@ private extension HomeViewController {
         if height > 230 && height < 620 {
             storeInformationHeightConstraint.constant = height
         }
-        if recognizer.state == .ended {
-            if storeInformationHeightConstraint.constant > 420 {
-                setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
-                setHeightConstraint(height: 600)
-            } else {
-                setHeightConstraint(height: storeInformationOriginalHeight)
-            }
-        }
         if recognizer.state == .changed {
             if storeInformationHeightConstraint.constant > 420 {
                 // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
@@ -356,7 +348,14 @@ private extension HomeViewController {
                 setBottomConstraints(constraint: -16)
             }
         }
-        
+        if recognizer.state == .ended {
+            if storeInformationHeightConstraint.constant > 420 {
+                setBottomConstraints(constraint: 600 - 441)
+                setHeightConstraint(height: 600)
+            } else {
+                setHeightConstraint(height: storeInformationOriginalHeight)
+            }
+        }
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -101,15 +101,6 @@ final class HomeViewController: UIViewController {
         
         return map
     }()
-        
-    private lazy var locationBottomConstraint = locationButton.bottomAnchor.constraint(
-        equalTo: mapView.safeAreaLayoutGuide.bottomAnchor,
-        constant: -16
-    )
-    private lazy var refreshBottomConstraint = refreshButton.bottomAnchor.constraint(
-        equalTo: mapView.safeAreaLayoutGuide.bottomAnchor,
-        constant: -17
-    )
     
     private let requestLocationServiceAlert: UIAlertController = {
         let alertController = UIAlertController(
@@ -171,16 +162,36 @@ final class HomeViewController: UIViewController {
         return button
     }()
     
+    private lazy var storeInformationView: StoreInformationView = {
+        let view = StoreInformationView(
+            summaryViewModel: summaryInformationViewModel,
+            summaryInformationHeightObserver: summaryInformationHeightObserver
+        )
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
     private var activatedFilter: [CertificationType] = []
-    
-    private var storeInformationViewController: SummaryInformationView?
-    
-    private let dismissObserver = PublishRelay<Void>()
-    
     private let viewModel: HomeViewModel
+    private let summaryInformationViewModel: SummaryInformationViewModel
+    private lazy var storeInformationHeightConstraint = storeInformationView.heightAnchor.constraint(equalToConstant: 0)
+    private lazy var locationButtonBottomConstraint = locationButton.bottomAnchor.constraint(
+        equalTo: storeInformationView.topAnchor,
+        constant: -37
+    )
+    private lazy var refreshButtonBottomConstraint = refreshButton.bottomAnchor.constraint(
+        equalTo: storeInformationView.topAnchor,
+        constant: -37
+    )
+    private let summaryInformationHeightObserver = PublishRelay<CGFloat>()
     
-    init(viewModel: HomeViewModel) {
+    init(
+        viewModel: HomeViewModel,
+        summaryInformationViewModel: SummaryInformationViewModel
+    ) {
         self.viewModel = viewModel
+        self.summaryInformationViewModel = summaryInformationViewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -212,17 +223,26 @@ private extension HomeViewController {
                         self.setMarker(marker: Marker(certificationType: filteredStore.type, position: location), tag: UInt($0.id))
                     }
                 }
-                storeInformationViewController?.dismiss(animated: true)
+                storeInformationViewDismiss()
             }
             .disposed(by: disposeBag)
         
         viewModel.getStoreInformationOutput
             .bind { [weak self] store in
                 guard let self = self else { return }
-                presentStoreView()
-                storeInformationViewController?.setUIContents(store: store)
+                storeInformationView.setUIContents(store: store)
             }
             .disposed(by: disposeBag)
+        
+        summaryInformationHeightObserver.bind { [weak self] height in
+            self?.storeInformationHeightConstraint.constant = height
+            self?.locationButtonBottomConstraint.constant = -16
+            self?.refreshButtonBottomConstraint.constant = -16
+            UIView.animate(withDuration: 0.3) { [weak self] in
+                self?.view.layoutIfNeeded()
+            }
+        }
+        .disposed(by: disposeBag)
     }
     
     func bindFilterButton(button: FilterButton, type: CertificationType) {
@@ -266,9 +286,8 @@ private extension HomeViewController {
             if let clickedMarker = self?.clickedMarker {
                 if clickedMarker == marker { return true }
                 if clickedMarker.isSelected {
-                    self?.storeInformationViewController?.dismiss(animated: true) { [weak self] in
-                        self?.markerSelected(marker: marker)
-                    }
+                    self?.storeInformationViewDismiss()
+                    self?.markerSelected(marker: marker)
                 } else {
                     self?.markerSelected(marker: marker)
                 }
@@ -288,47 +307,14 @@ private extension HomeViewController {
         clickedMarker = marker
     }
     
-    func markerClicked(height: CGFloat) {
-        mapView.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: height, right: 0)
-        locationBottomConstraint.constant = -height
-        refreshBottomConstraint.constant = -height
-        UIView.animate(withDuration: 0.3) {
-            self.view.layoutIfNeeded()
-        }
-    }
-    
-    func presentStoreView() {
-        let storeViewModel = StoreInformationViewModelImpl(
-            getOpenClosedUseCase: GetOpenClosedUseCaseImpl(),
-            fetchImageUseCase: FetchImageUseCaseImpl(repository: ImageRepositoryImpl())
-        )
-        let contentHeightObserver = PublishRelay<CGFloat>()
-        storeInformationViewController = SummaryInformationView(
-            viewModel: storeViewModel,
-            contentHeightObserver: contentHeightObserver,
-            dismissObserver: dismissObserver
-        )
-        storeInformationViewController?.transitioningDelegate = self
-        
-        if let viewController = storeInformationViewController {
-            contentHeightObserver
-                .bind { [weak self] contentHeight in
-                    guard let self = self else { return }
-                    let bottomSafeArea: CGFloat = 34
-                    let height = contentHeight - bottomSafeArea
-                    if let sheet = viewController.sheetPresentationController {
-                        let detentIdentifier = UISheetPresentationController.Detent.Identifier("detent")
-                        let detent = UISheetPresentationController.Detent.custom(identifier: detentIdentifier) { _ in
-                            return height
-                        }
-                        sheet.detents = [detent]
-                        sheet.largestUndimmedDetentIdentifier = detentIdentifier
-                        sheet.preferredCornerRadius = 15
-                    }
-                    markerClicked(height: contentHeight - bottomSafeArea + 16)
-                }
-                .disposed(by: disposeBag)
-            present(viewController, animated: true)
+    func storeInformationViewDismiss() {
+        clickedMarker?.isSelected = false
+        clickedMarker = nil
+        storeInformationHeightConstraint.constant = 0
+        locationButtonBottomConstraint.constant = -37
+        refreshButtonBottomConstraint.constant = -37
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.view.layoutIfNeeded()
         }
     }
     
@@ -366,6 +352,7 @@ private extension HomeViewController {
         mapView.addSubview(locationButton)
         mapView.addSubview(filterButtonStackView)
         mapView.addSubview(refreshButton)
+        mapView.addSubview(storeInformationView)
     }
     
     func configureConstraints() {
@@ -380,7 +367,7 @@ private extension HomeViewController {
             locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             locationButton.widthAnchor.constraint(equalToConstant: 48),
             locationButton.heightAnchor.constraint(equalToConstant: 48),
-            locationBottomConstraint
+            locationButtonBottomConstraint
         ])
         
         NSLayoutConstraint.activate([
@@ -390,7 +377,14 @@ private extension HomeViewController {
         
         NSLayoutConstraint.activate([
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
-            refreshBottomConstraint
+            refreshButtonBottomConstraint
+        ])
+        
+        NSLayoutConstraint.activate([
+            storeInformationView.leadingAnchor.constraint(equalTo: mapView.leadingAnchor, constant: 0),
+            storeInformationView.trailingAnchor.constraint(equalTo: mapView.trailingAnchor, constant: 0),
+            storeInformationView.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: 0),
+            storeInformationHeightConstraint
         ])
     }
     
@@ -454,28 +448,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
 extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
-        storeInformationViewController?.dismiss(animated: true)
-    }
-    
-}
-
-extension HomeViewController: UIViewControllerTransitioningDelegate {
-    
-    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        dismissObserver
-            .bind { [weak self] in
-                guard let self = self else { return }
-                clickedMarker?.isSelected = false
-                mapView.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-                locationBottomConstraint.constant = -16
-                refreshBottomConstraint.constant = -17
-                UIView.animate(withDuration: 0.3) {
-                    self.view.layoutIfNeeded()
-                }
-            }
-            .disposed(by: disposeBag)
-        
-        return nil
+        storeInformationViewDismiss()
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -28,7 +28,6 @@ final class StoreInformationView: UIView {
         self.summaryInformationHeightObserver = summaryInformationHeightObserver
         super.init(frame: .zero)
         
-//        setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         addUIComponents()
         configureConstraints()
     }

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -1,0 +1,75 @@
+//
+//  StoreInformationView.swift
+//  KCS
+//
+//  Created by 김영현 on 1/24/24.
+//
+
+import UIKit
+
+final class StoreInformationView: UIView {
+    
+    lazy var summaryView: SummaryInformationView = {
+        let view = SummaryInformationView(viewModel: self.summaryViewModel)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    let summaryViewModel: SummaryInformationViewModel
+    
+    init(summaryViewModel: SummaryInformationViewModel) {
+        self.summaryViewModel = summaryViewModel
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension StoreInformationView {
+    
+    func addUIComponents() {
+        addSubview(summaryView)
+    }
+    
+    func configureConstraints() {
+        
+        NSLayoutConstraint.activate([
+            summaryView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            summaryView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            summaryView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            summaryView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+        ])
+        
+    }
+    
+}
+
+//@objc
+//extension StoreInformationView {
+//    
+//    func customViewDrag(_ recognizer: UIPanGestureRecognizer) {
+//        let transition = recognizer.translation(in: summaryView)
+//        let height = summaryView.bounds.height - transition.y
+//        
+//        recognizer.setTranslation(.zero, in: summaryView)
+//        
+//        if height > 230 && height < 620 {
+//            heightConstraint.constant = height
+//        }
+//        if recognizer.state == .ended {
+//            if heightConstraint.constant > 400 {
+//                heightConstraint.constant = 600
+//            } else {
+//                heightConstraint.constant = 250
+//            }
+//            UIView.animate(withDuration: 0.3) { [weak self] in
+//                self?.view.layoutIfNeeded()
+//            }
+//        }
+//    }
+//    
+//}

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -28,6 +28,7 @@ final class StoreInformationView: UIView {
         self.summaryInformationHeightObserver = summaryInformationHeightObserver
         super.init(frame: .zero)
         
+//        setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         addUIComponents()
         configureConstraints()
     }
@@ -64,29 +65,3 @@ private extension StoreInformationView {
     }
     
 }
-
-//@objc
-//extension StoreInformationView {
-//    
-//    func customViewDrag(_ recognizer: UIPanGestureRecognizer) {
-//        let transition = recognizer.translation(in: summaryView)
-//        let height = summaryView.bounds.height - transition.y
-//        
-//        recognizer.setTranslation(.zero, in: summaryView)
-//        
-//        if height > 230 && height < 620 {
-//            heightConstraint.constant = height
-//        }
-//        if recognizer.state == .ended {
-//            if heightConstraint.constant > 400 {
-//                heightConstraint.constant = 600
-//            } else {
-//                heightConstraint.constant = 250
-//            }
-//            UIView.animate(withDuration: 0.3) { [weak self] in
-//                self?.view.layoutIfNeeded()
-//            }
-//        }
-//    }
-//    
-//}

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -6,21 +6,30 @@
 //
 
 import UIKit
+import RxRelay
 
 final class StoreInformationView: UIView {
     
-    lazy var summaryView: SummaryInformationView = {
-        let view = SummaryInformationView(viewModel: self.summaryViewModel)
+    private lazy var summaryView: SummaryInformationView = {
+        let view = SummaryInformationView(
+            viewModel: summaryViewModel,
+            summaryInformationHeightObserver: summaryInformationHeightObserver
+        )
         view.translatesAutoresizingMaskIntoConstraints = false
         
         return view
     }()
     
-    let summaryViewModel: SummaryInformationViewModel
+    private let summaryViewModel: SummaryInformationViewModel
+    private let summaryInformationHeightObserver: PublishRelay<CGFloat>
     
-    init(summaryViewModel: SummaryInformationViewModel) {
+    init(summaryViewModel: SummaryInformationViewModel, summaryInformationHeightObserver: PublishRelay<CGFloat>) {
         self.summaryViewModel = summaryViewModel
-        super.init()
+        self.summaryInformationHeightObserver = summaryInformationHeightObserver
+        super.init(frame: .zero)
+        
+        addUIComponents()
+        configureConstraints()
     }
     
     required init?(coder: NSCoder) {
@@ -31,6 +40,14 @@ final class StoreInformationView: UIView {
 
 extension StoreInformationView {
     
+    func setUIContents(store: Store) {
+        summaryView.setUIContents(store: store)
+    }
+    
+}
+
+private extension StoreInformationView {
+    
     func addUIComponents() {
         addSubview(summaryView)
     }
@@ -38,10 +55,10 @@ extension StoreInformationView {
     func configureConstraints() {
         
         NSLayoutConstraint.activate([
-            summaryView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            summaryView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            summaryView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            summaryView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+            summaryView.topAnchor.constraint(equalTo: topAnchor),
+            summaryView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            summaryView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            summaryView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
         
     }

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -92,10 +92,12 @@ final class SummaryInformationView: UIView {
     }()
     
     private let viewModel: SummaryInformationViewModel
+    private let summaryInformationHeightObserver: PublishRelay<CGFloat>
     
-    init(viewModel: SummaryInformationViewModel) {
+    init(viewModel: SummaryInformationViewModel, summaryInformationHeightObserver: PublishRelay<CGFloat>) {
         self.viewModel = viewModel
-        super.init()
+        self.summaryInformationHeightObserver = summaryInformationHeightObserver
+        super.init(frame: .zero)
         
         setBackgroundColor()
         addUIComponents()
@@ -143,9 +145,9 @@ private extension SummaryInformationView {
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            storeTitle.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 27),
-            storeTitle.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            storeTitle.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -156)
+            storeTitle.topAnchor.constraint(equalTo: topAnchor, constant: 27),
+            storeTitle.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            storeTitle.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -156)
         ])
         
         NSLayoutConstraint.activate([
@@ -170,7 +172,6 @@ private extension SummaryInformationView {
         
         NSLayoutConstraint.activate([
             storeCallButton.topAnchor.constraint(equalTo: storeOpenClosed.bottomAnchor, constant: 21),
-            storeCallButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
             storeCallButton.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor),
             storeCallButton.widthAnchor.constraint(equalToConstant: 69),
             storeCallButton.heightAnchor.constraint(equalToConstant: 40)
@@ -217,6 +218,11 @@ extension SummaryInformationView {
             openingHour: store.openingHour,
             url: store.localPhotos.first)
         )
+        if storeTitle.numberOfVisibleLines == 1 {
+            summaryInformationHeightObserver.accept(230)
+        } else {
+            summaryInformationHeightObserver.accept(253)
+        }
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -209,16 +209,23 @@ extension SummaryInformationView {
                 certificationStackView.addArrangedSubview($0)
             }
         if let phoneNum = store.phoneNumber {
+            storeCallButton.isEnabled = true
             storeCallButton.rx.tap
                 .bind { [weak self] _ in
                     self?.callButtonTapped(phoneNum: phoneNum)
                 }
                 .disposed(by: disposeBag)
+        } else {
+            storeCallButton.isEnabled = false
         }
-        viewModel.action(input: .setInformationView(
-            openingHour: store.openingHour,
-            url: store.localPhotos.first)
-        )
+        if let url = store.localPhotos.first {
+            viewModel.action(input: .setInformationView(
+                openingHour: store.openingHour,
+                url: store.localPhotos.first)
+            )
+        } else {
+            storeImageView.image = UIImage.basicStore
+        }
         if storeTitle.numberOfVisibleLines == 1 {
             summaryInformationHeightObserver.accept(230)
         } else {

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -100,6 +100,7 @@ final class SummaryInformationView: UIView {
         super.init(frame: .zero)
         
         setBackgroundColor()
+        setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         addUIComponents()
         configureConstraints()
         bind()

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -1,5 +1,5 @@
 //
-//  StoreInformationViewController.swift
+//  SummaryInformationView.swift
 //  KCS
 //
 //  Created by 김영현 on 1/11/24.
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class StoreInformationViewController: UIViewController {
+final class SummaryInformationView: UIView {
     
     private let disposeBag = DisposeBag()
     
@@ -91,15 +91,11 @@ final class StoreInformationViewController: UIViewController {
         return view
     }()
     
-    private let viewModel: StoreInformationViewModel
-    private let contentHeightObserver: PublishRelay<CGFloat>
-    private let dismissObserver: PublishRelay<Void>
+    private let viewModel: SummaryInformationViewModel
     
-    init(viewModel: StoreInformationViewModel, contentHeightObserver: PublishRelay<CGFloat>, dismissObserver: PublishRelay<Void>) {
+    init(viewModel: SummaryInformationViewModel) {
         self.viewModel = viewModel
-        self.contentHeightObserver = contentHeightObserver
-        self.dismissObserver = dismissObserver
-        super.init(nibName: nil, bundle: nil)
+        super.init()
         
         setBackgroundColor()
         addUIComponents()
@@ -107,16 +103,12 @@ final class StoreInformationViewController: UIViewController {
         bind()
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        dismissObserver.accept(())
-    }
-    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
 
-private extension StoreInformationViewController {
+private extension SummaryInformationView {
     
     func bind() {
         viewModel.thumbnailImageOutput
@@ -135,25 +127,25 @@ private extension StoreInformationViewController {
     }
     
     func setBackgroundColor() {
-        view.backgroundColor = .white
+        backgroundColor = .white
     }
     
     func addUIComponents() {
-        view.addSubview(storeTitle)
-        view.addSubview(certificationStackView)
-        view.addSubview(category)
-        view.addSubview(storeOpenClosed)
-        view.addSubview(openingHour)
-        view.addSubview(storeImageView)
-        view.addSubview(storeCallButton)
-        view.addSubview(dismissIndicatorView)
+        addSubview(storeTitle)
+        addSubview(certificationStackView)
+        addSubview(category)
+        addSubview(storeOpenClosed)
+        addSubview(openingHour)
+        addSubview(storeImageView)
+        addSubview(storeCallButton)
+        addSubview(dismissIndicatorView)
     }
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            storeTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 27),
-            storeTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            storeTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -156)
+            storeTitle.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 27),
+            storeTitle.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            storeTitle.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -156)
         ])
         
         NSLayoutConstraint.activate([
@@ -178,21 +170,22 @@ private extension StoreInformationViewController {
         
         NSLayoutConstraint.activate([
             storeCallButton.topAnchor.constraint(equalTo: storeOpenClosed.bottomAnchor, constant: 21),
+            storeCallButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
             storeCallButton.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor),
             storeCallButton.widthAnchor.constraint(equalToConstant: 69),
             storeCallButton.heightAnchor.constraint(equalToConstant: 40)
         ])
         
         NSLayoutConstraint.activate([
-            storeImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 27),
-            storeImageView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            storeImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 27),
+            storeImageView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
             storeImageView.widthAnchor.constraint(equalToConstant: 132),
             storeImageView.heightAnchor.constraint(equalToConstant: 132)
         ])
         
         NSLayoutConstraint.activate([
-            dismissIndicatorView.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
-            dismissIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dismissIndicatorView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            dismissIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
             dismissIndicatorView.widthAnchor.constraint(equalToConstant: 35),
             dismissIndicatorView.heightAnchor.constraint(equalToConstant: 4)
         ])
@@ -200,7 +193,7 @@ private extension StoreInformationViewController {
     
 }
 
-extension StoreInformationViewController {
+extension SummaryInformationView {
     
     func setUIContents(store: Store) {
         storeTitle.text = store.title
@@ -224,16 +217,11 @@ extension StoreInformationViewController {
             openingHour: store.openingHour,
             url: store.localPhotos.first)
         )
-        if storeTitle.numberOfVisibleLines > 1 {
-            contentHeightObserver.accept(253)
-        } else {
-            contentHeightObserver.accept(230)
-        }
     }
     
 }
 
-private extension StoreInformationViewController {
+private extension SummaryInformationView {
     
     func removeStackView() {
         let subviews = certificationStackView.arrangedSubviews

--- a/KCS/KCS/Presentation/Home/ViewModel/StoreInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/StoreInformationViewModelImpl.swift
@@ -8,7 +8,7 @@
 import RxSwift
 import RxRelay
 
-final class StoreInformationViewModelImpl: StoreInformationViewModel {
+final class StoreInformationViewModelImpl: SummaryInformationViewModel {
     
     private let disposeBag = DisposeBag()
     

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryInformationViewModelImpl.swift
@@ -1,5 +1,5 @@
 //
-//  StoreInformationViewModelImpl.swift
+//  SummaryInformationViewModelImpl.swift
 //  KCS
 //
 //  Created by 김영현 on 1/18/24.
@@ -8,7 +8,7 @@
 import RxSwift
 import RxRelay
 
-final class StoreInformationViewModelImpl: SummaryInformationViewModel {
+final class SummaryInformationViewModelImpl: SummaryInformationViewModel {
     
     private let disposeBag = DisposeBag()
     
@@ -35,7 +35,7 @@ final class StoreInformationViewModelImpl: SummaryInformationViewModel {
     
 }
 
-private extension StoreInformationViewModelImpl {
+private extension SummaryInformationViewModelImpl {
     
     func setOpenClosed(
         openingHour: [RegularOpeningHours]

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryInformationViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  StoreInformationViewModel.swift
+//  SummaryInformationViewModel.swift
 //  KCS
 //
 //  Created by 김영현 on 1/18/24.
@@ -8,7 +8,7 @@
 import RxSwift
 import RxRelay
 
-protocol StoreInformationViewModel: StoreInformationViewModelInput, StoreInformationViewModelOutput {
+protocol SummaryInformationViewModel: StoreInformationViewModelInput, StoreInformationViewModelOutput {
     
     var getOpenClosedUseCase: GetOpenClosedUseCase { get }
     var fetchImageUseCase: FetchImageUseCase { get }


### PR DESCRIPTION
## ⭐️ Issue Number

- #105 

## 🚩 Summary

요약 정보 카드를 UIView로 바꾸고 바뀐 StoreInformationView에 제스쳐 애니메이션을 추가한다.

![Simulator Screen Recording - iPhone 15 - 2024-01-24 at 05 51 57](https://github.com/Korea-Certified-Store/iOS/assets/62226667/d323e9a3-9353-4ee7-ab9e-80e99ea2da19)

## 🛠️ Technical Concerns

### UIView vs UISheetPresentationViewController

 원래 가게의 요약 정보 카드는 ```UISheetPresentationViewController```를 사용하여 구현했었다.
하지만 ```UISheetPresentationViewController```를 사용하니 다음과 같은 단점들이 존재했다.

- bottom sheet를 띄우는 데 다음 ViewController의 View가 present되고 dismiss 되기까지의 시점이 잘 맞지 않아 동기적으로 처리하기가 힘들다.
- ```UISheetPresentationViewController```는 WWDC 2021에서 발표된 최신 기술이기 때문에 자료가 많이 없어, 학습하는데에 있어 큰 어려움이 있다.
- 커스텀과 관련된 기능들을 충분히 제공하지 않아 원하는 기술을 커스텀하여 구현하는데 한계가 있었다.

이렇게 단점들이 많고 ```UIGetstureRecognizer```를 사용하면 ```UIView```만으로도 충분히 구현가능하다고 판단되어 ```UISheetPresentationViewController```를 사용하지 않고 UIView롤 재구현하게 되었다.

### UIPanGestureRecognizer

GestureRecognizer에는 여러 종류가 있다. 

- ```UITapGestureRecognizer``` : 짧게 터치하는 하나 이상의 손가락을 인식
- ```UISwipeGestureRecognizer``` : swipe 제스처를 인식
- ```UIPinchGestureRecognizer``` : 핀치 제스처를 인식
- ```UIRotationGestureRecognizer``` : 로테이션 제스처를 인식
- ```UIPanGestureRecognizer``` : 팬 제스처를 인식 (=drag)
- ```UILongPressGestureRecognizer``` : View에서 길게 터치하는 Continuous 제스처

 위와 같은 여러 제스처들 가운데 UIView에 우리가 원하는 기능을 구현하기 위해 우선 ```UIPanGestureRecognizer```가 필요했다.
해당 제스처는 drag와 같은 제스처를 인식할 수 있고 제스처의 상황별로 원하는 기능을 구현할 수 있었다.

```swift
if recognizer.state == .ended {
    if storeInformationHeightConstraint.constant > 420 {
        setNewConstraints(storeInformationHeight: 600)
    } else {
        setNewConstraints(storeInformationHeight: storeInformationOriginalHeight)
    }
}
```
```swift
if recognizer.state == .changed {
    if storeInformationHeightConstraint.constant > 420 {
        // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
        locationButtonBottomConstraint.constant = storeInformationHeightConstraint.constant - 441
        refreshButtonBottomConstraint.constant = storeInformationHeightConstraint.constant - 441
    } else {
        locationButtonBottomConstraint.constant = -16
        refreshButtonBottomConstraint.constant = -16
    }
}
```

## 📋 To Do

- constraint 값에 대한 수치를 명확히 해야합니다.
- 추후 GestureRecognizer를 rx를 통해 등록하는 방식으로 바꿔야 합니다.