### PR TITLE
요약 카드 RxGesture

### DIFF
--- a/KCS/Podfile
+++ b/KCS/Podfile
@@ -10,6 +10,7 @@ target 'KCS' do
    
   pod 'RxSwift', '6.6.0'
   pod 'RxCocoa', '6.6.0'
+  pod 'RxGesture'
   pod 'Alamofire'
   pod 'SwiftLint'
   pod 'NMapsMap'

--- a/KCS/Podfile.lock
+++ b/KCS/Podfile.lock
@@ -8,6 +8,9 @@ PODS:
   - RxCocoa (6.6.0):
     - RxRelay (= 6.6.0)
     - RxSwift (= 6.6.0)
+  - RxGesture (4.0.4):
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - RxRelay (6.6.0):
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
@@ -20,6 +23,7 @@ DEPENDENCIES:
   - NMapsMap
   - RxBlocking
   - RxCocoa (= 6.6.0)
+  - RxGesture
   - RxSwift (= 6.6.0)
   - RxTest
   - SwiftLint
@@ -31,6 +35,7 @@ SPEC REPOS:
     - NMapsMap
     - RxBlocking
     - RxCocoa
+    - RxGesture
     - RxRelay
     - RxSwift
     - RxTest
@@ -42,11 +47,12 @@ SPEC CHECKSUMS:
   NMapsMap: a5b909a31b6f3d27a670f6eb2ddc913c38975474
   RxBlocking: fbd1f8501443024f686e556f36dac79b0d5f4d7c
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
+  RxGesture: f3efb47ed2d26a8082f7b660d4a59970e275a7f8
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   RxTest: a23f26bb53a5e146a0a69db4f0fa0b69001ce7f4
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 0f88675320ac9cb6ad8c84bdece01c7160cd9d79
+PODFILE CHECKSUM: 529859231e49f63fa881147a916b977cb8f574df
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
## ⭐️ Issue Number

- #109

## 🚩 Summary

- UIPanGestureRecognizer -> RxGesture로 변경
- 스와이프 구현

![Simulator Screen Recording - iPhone 15 Pro - 2024-01-24 at 19 27 58](https://github.com/Korea-Certified-Store/iOS/assets/128480641/828b02e4-4215-4a2c-8641-20020e65c90b)

## 🛠️ Technical Concerns

### Swipe 구현 방식

스와이프를 구현하는 방식을 3가지를 시도했다. 

- RxGesture.swipeGesture().when(.recognized)
  > 스와이프 모션을 인식하여 코드 블럭을 실행시킨다. 
이는 속도가 어느 정도 이상이 되면 자동으로 스와이프가 되는 것이기 때문에 속도가 다시 줄어들었을 경우를 인식할 수 없다. 
속도가 빠른 상태에서 Gesture가 끝나야 스와이프 동작이 이루어져야 하기 때문에 원하던 방식이 아니었다.

-  panGesture().when(.changed)
    > 해당 방법도 위와 마찬가지로 중간에 속도가 특정 수치를 넘어갔다고 해서 스와이프를 작동시키면 
    사용자의 제스처가 끝나지 않았는데 제스처를 마무리 짓기 때문에 원하던 구현 방식이 아니었다.
-  panGesture().when(.ended)
    > 마지막 속도가 특정 수치 이상이면 스와이프로 인식하여 원하는 코드 블럭을 실행시킬 수 있었다. 
    수치는 y축 1000, -1000으로 위 아래 방향 스와이프로 구현했다.
   
