### PR TITLE
상세 정보 UIView

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		591A88812B384E600059E40F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591A88802B384E600059E40F /* HomeViewController.swift */; };
 		591A88862B384E610059E40F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 591A88852B384E610059E40F /* Assets.xcassets */; };
 		591A88892B384E610059E40F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 591A88872B384E610059E40F /* LaunchScreen.storyboard */; };
+		592262242B61203000CA5A11 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262232B61203000CA5A11 /* DetailView.swift */; };
+		592262262B61232F00CA5A11 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262252B61232F00CA5A11 /* DetailViewModel.swift */; };
+		592262282B6124C400CA5A11 /* DetailViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
 		5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE5B2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift */; };
 		5977BE5E2B5535C700725C90 /* FetchRefreshStoresUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE5D2B5535C700725C90 /* FetchRefreshStoresUseCase.swift */; };
@@ -107,6 +110,9 @@
 		591A88852B384E610059E40F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		591A88882B384E610059E40F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		591A888A2B384E610059E40F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		592262232B61203000CA5A11 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		592262252B61232F00CA5A11 /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
+		592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModelImpl.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
 		5977BE5B2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRefreshStoresUseCaseImpl.swift; sourceTree = "<group>"; };
 		5977BE5D2B5535C700725C90 /* FetchRefreshStoresUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRefreshStoresUseCase.swift; sourceTree = "<group>"; };
@@ -271,6 +277,7 @@
 				5977BE652B553BA800725C90 /* HomeViewModelImpl.swift */,
 				5977BE672B553C8300725C90 /* HomeDependency.swift */,
 				A8ACB7E12B594F7400540BD1 /* SummaryInformationViewModelImpl.swift */,
+				592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -365,6 +372,7 @@
 				A802D1F52B5277620091FDE7 /* CertificationLabel.swift */,
 				5977BE572B5524D500725C90 /* RefreshButton.swift */,
 				A81EFBD32B6019FD00D0C0D7 /* StoreInformationView.swift */,
+				592262232B61203000CA5A11 /* DetailView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -519,6 +527,7 @@
 			children = (
 				5977BE602B55374000725C90 /* HomeViewModel.swift */,
 				A8ACB7DE2B594F4B00540BD1 /* SummaryInformationViewModel.swift */,
+				592262252B61232F00CA5A11 /* DetailViewModel.swift */,
 			);
 			path = protocol;
 			sourceTree = "<group>";
@@ -774,6 +783,8 @@
 				5977BE612B55374000725C90 /* HomeViewModel.swift in Sources */,
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
 				59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */,
+				592262282B6124C400CA5A11 /* DetailViewModelImpl.swift in Sources */,
+				592262262B61232F00CA5A11 /* DetailViewModel.swift in Sources */,
 				59C306C92B501B9D00862625 /* RegularOpeningHours.swift in Sources */,
 				59F478B52B59BE0B002FEF9E /* FetchImageUseCase.swift in Sources */,
 				59C306BF2B50109100862625 /* Location.swift in Sources */,
@@ -793,6 +804,7 @@
 				59C306A42B4D7EBA00862625 /* Marker.swift in Sources */,
 				A81EFBD42B6019FD00D0C0D7 /* StoreInformationView.swift in Sources */,
 				5977BE662B553BA800725C90 /* HomeViewModelImpl.swift in Sources */,
+				592262242B61203000CA5A11 /* DetailView.swift in Sources */,
 				A81EFBB32B5BC57800D0C0D7 /* OpenClosedContent.swift in Sources */,
 				5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */,
 				A8ACB7E22B594F7400540BD1 /* SummaryInformationViewModelImpl.swift in Sources */,

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -28,7 +28,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             getOpenClosedUseCase: GetOpenClosedUseCaseImpl(),
             fetchImageUseCase: FetchImageUseCaseImpl(repository: ImageRepositoryImpl())
         )
-        window?.rootViewController = HomeViewController(viewModel: viewModel, summaryInformationViewModel: summaryInformationViewModel)
+        window?.rootViewController = HomeViewController(
+            viewModel: viewModel,
+            summaryInformationViewModel: summaryInformationViewModel,
+            detailViewModel: DetailViewModelImpl()
+        )
         window?.makeKeyAndVisible()
     }
 

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -1,0 +1,195 @@
+//
+//  DetailView.swift
+//  KCS
+//
+//  Created by 조성민 on 1/24/24.
+//
+
+import UIKit
+import RxSwift
+
+final class DetailView: UIView {
+    
+    private let disposeBag = DisposeBag()
+    
+    private lazy var storeTitle: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.pretendard(size: 22, weight: .bold)
+        label.textColor = UIColor.primary2
+        label.numberOfLines = 2
+        
+        return label
+    }()
+    
+    private lazy var category: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.pretendard(size: 13, weight: .regular)
+        label.textColor = UIColor.kcsGray
+        
+        return label
+    }()
+    
+    private lazy var certificationStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.distribution = .fillProportionally
+        
+        return stack
+    }()
+    
+    private lazy var storeOpenClosed: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.pretendard(size: 15, weight: .regular)
+        label.textColor = UIColor.goodPrice
+        
+        return label
+    }()
+    
+    private lazy var openingHour: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.pretendard(size: 13, weight: .regular)
+        label.textColor = UIColor.kcsGray
+        
+        return label
+    }()
+    
+    private let storeImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.setLayerCorner(cornerRadius: 6)
+        imageView.clipsToBounds = true
+        imageView.image = UIImage.basicStore
+        
+        return imageView
+    }()
+    
+    private let address: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let phoneNumber: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let dismissIndicatorView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor.swipeBar
+        view.layer.cornerRadius = 2
+        
+        return view
+    }()
+    
+    private let viewModel: DetailViewModel
+    
+    init(viewModel: DetailViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
+        
+        setBackgroundColor()
+        setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        addUIComponents()
+        configureConstraints()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension DetailView {
+    
+    func bind() {
+        
+    }
+    
+}
+private extension DetailView {
+    
+    func setBackgroundColor() {
+        backgroundColor = .white
+    }
+    
+    func addUIComponents() {
+        addSubview(storeTitle)
+        addSubview(certificationStackView)
+        addSubview(category)
+        addSubview(storeOpenClosed)
+        addSubview(openingHour)
+        addSubview(storeImageView)
+        addSubview(dismissIndicatorView)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            storeTitle.topAnchor.constraint(equalTo: topAnchor, constant: 27),
+            storeTitle.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            storeTitle.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -156)
+        ])
+        
+        NSLayoutConstraint.activate([
+            category.topAnchor.constraint(equalTo: storeTitle.bottomAnchor, constant: 4),
+            category.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            certificationStackView.topAnchor.constraint(equalTo: category.bottomAnchor, constant: 9),
+            certificationStackView.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            storeOpenClosed.topAnchor.constraint(equalTo: certificationStackView.bottomAnchor, constant: 8),
+            storeOpenClosed.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            openingHour.centerYAnchor.constraint(equalTo: storeOpenClosed.centerYAnchor),
+            openingHour.leadingAnchor.constraint(equalTo: storeOpenClosed.trailingAnchor, constant: 12)
+        ])
+        
+        NSLayoutConstraint.activate([
+            storeImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 27),
+            storeImageView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            storeImageView.widthAnchor.constraint(equalToConstant: 132),
+            storeImageView.heightAnchor.constraint(equalToConstant: 132)
+        ])
+        
+        NSLayoutConstraint.activate([
+            dismissIndicatorView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            dismissIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            dismissIndicatorView.widthAnchor.constraint(equalToConstant: 35),
+            dismissIndicatorView.heightAnchor.constraint(equalToConstant: 4)
+        ])
+    }
+    
+    func setUIContents(store: Store) {
+    }
+    
+    func removeStackView() {
+        let subviews = certificationStackView.arrangedSubviews
+        certificationStackView.arrangedSubviews.forEach {
+            certificationStackView.removeArrangedSubview($0)
+        }
+        subviews.forEach { $0.removeFromSuperview() }
+    }
+    
+    func callTapped() {
+        if let number = phoneNumber.text , let url = URL(string: "tel://" + "\(number.filter { $0.isNumber })") {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+    
+}

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -123,7 +123,6 @@ private extension DetailView {
 private extension DetailView {
     
     func setBackgroundColor() {
-        //        backgroundColor = .white
         backgroundColor = .systemYellow
     }
     

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 
+// TODO: UI 요소 전체를 디자인에 맞게 수정해야 합니다.
 final class DetailView: UIView {
     
     private let disposeBag = DisposeBag()

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -108,6 +108,7 @@ final class DetailView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
 }
 
 private extension DetailView {
@@ -117,10 +118,12 @@ private extension DetailView {
     }
     
 }
+
 private extension DetailView {
     
     func setBackgroundColor() {
-        backgroundColor = .white
+        //        backgroundColor = .white
+        backgroundColor = .systemYellow
     }
     
     func addUIComponents() {
@@ -175,9 +178,6 @@ private extension DetailView {
         ])
     }
     
-    func setUIContents(store: Store) {
-    }
-    
     func removeStackView() {
         let subviews = certificationStackView.arrangedSubviews
         certificationStackView.arrangedSubviews.forEach {
@@ -187,9 +187,17 @@ private extension DetailView {
     }
     
     func callTapped() {
-        if let number = phoneNumber.text , let url = URL(string: "tel://" + "\(number.filter { $0.isNumber })") {
+        if let number = phoneNumber.text, let url = URL(string: "tel://" + "\(number.filter { $0.isNumber })") {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
+    }
+    
+}
+
+extension DetailView {
+    
+    func setUIContents(store: Store) {
+        
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -246,7 +246,7 @@ final class HomeViewController: UIViewController {
         
         view.rx.tapGesture()
             .when(.ended)
-            .subscribe(onNext: {[weak self] recognizer in
+            .subscribe(onNext: {[weak self] _ in
                 guard let self = self else { return }
                 if storeInformationHeightConstraint.constant == storeInformationOriginalHeight {
                     setStoreInformationConstraints(

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -170,6 +170,7 @@ final class HomeViewController: UIViewController {
         )
         view.translatesAutoresizingMaskIntoConstraints = false
         
+        // TODO: 로직 뷰모델로 이동
         view.rx.panGesture()
             .when(.changed)
             .subscribe(onNext: { [weak self] recognizer in

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -166,7 +166,8 @@ final class HomeViewController: UIViewController {
     private lazy var storeInformationView: StoreInformationView = {
         let view = StoreInformationView(
             summaryViewModel: summaryInformationViewModel,
-            summaryInformationHeightObserver: summaryInformationHeightObserver
+            summaryInformationHeightObserver: summaryInformationHeightObserver,
+            detailViewModel: detailViewModel
         )
         view.translatesAutoresizingMaskIntoConstraints = false
         
@@ -214,13 +215,14 @@ final class HomeViewController: UIViewController {
                 }
             })
             .disposed(by: disposeBag)
-
+        
         return view
     }()
     
     private var activatedFilter: [CertificationType] = []
     private let viewModel: HomeViewModel
     private let summaryInformationViewModel: SummaryInformationViewModel
+    private let detailViewModel: DetailViewModel
     private lazy var storeInformationHeightConstraint = storeInformationView.heightAnchor.constraint(equalToConstant: 0)
     private lazy var locationButtonBottomConstraint = locationButton.bottomAnchor.constraint(
         equalTo: storeInformationView.topAnchor,
@@ -235,10 +237,12 @@ final class HomeViewController: UIViewController {
     
     init(
         viewModel: HomeViewModel,
-        summaryInformationViewModel: SummaryInformationViewModel
+        summaryInformationViewModel: SummaryInformationViewModel,
+        detailViewModel: DetailViewModel
     ) {
         self.viewModel = viewModel
         self.summaryInformationViewModel = summaryInformationViewModel
+        self.detailViewModel = detailViewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -287,6 +291,7 @@ private extension HomeViewController {
             self?.setHeightConstraint(height: height)
         }
         .disposed(by: disposeBag)
+    
     }
     
     func bindFilterButton(button: FilterButton, type: CertificationType) {
@@ -305,7 +310,7 @@ private extension HomeViewController {
             .bind(to: button.rx.isSelected)
             .disposed(by: disposeBag)
     }
-    
+
     func setMarker(marker: Marker, tag: UInt) {
         marker.tag = tag
         marker.mapView = mapView.mapView
@@ -320,7 +325,7 @@ private extension HomeViewController {
         
         return activatedFilter
     }
-    
+
 }
 
 private extension HomeViewController {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -182,17 +182,27 @@ final class HomeViewController: UIViewController {
                 recognizer.setTranslation(.zero, in: storeInformationView)
                 
                 if height > 230 && height < 620 {
-                    storeInformationHeightConstraint.constant = height
+                    setStoreInformationConstraints(
+                        heightConstraint: height,
+                        bottomConstraint: locationButtonBottomConstraint.constant
+                    )
                 }
                 
                 if storeInformationHeightConstraint.constant > 420 {
                     // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
                     storeInformationView.changeToDetail()
-                    setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
+                    setStoreInformationConstraints(
+                        heightConstraint: storeInformationHeightConstraint.constant,
+                        bottomConstraint: storeInformationHeightConstraint.constant - 441
+                    )
                 } else {
                     storeInformationView.changeToSummary()
-                    setBottomConstraints(constraint: -16)
+                    setStoreInformationConstraints(
+                        heightConstraint: storeInformationHeightConstraint.constant,
+                        bottomConstraint: -16
+                    )
                 }
+                
             })
             .disposed(by: disposeBag)
         
@@ -201,22 +211,34 @@ final class HomeViewController: UIViewController {
             .subscribe(onNext: { [weak self] recognizer in
                 guard let self = self else { return }
                 if recognizer.velocity(in: view).y < -1000 {
-                    setBottomConstraints(constraint: 600 - 441)
-                    setHeightConstraint(height: 600)
+                    setStoreInformationConstraints(
+                        heightConstraint: 600,
+                        bottomConstraint: 600 - 441,
+                        animated: true
+                    )
                     storeInformationView.changeToDetail()
                 } else if recognizer.velocity(in: view).y > 1000 {
-                    setBottomConstraints(constraint: -16)
-                    setHeightConstraint(height: storeInformationOriginalHeight)
+                    setStoreInformationConstraints(
+                        heightConstraint: storeInformationOriginalHeight,
+                        bottomConstraint: -16,
+                        animated: true
+                    )
                     storeInformationView.changeToSummary()
                 }
                 
                 if storeInformationHeightConstraint.constant > 420 {
-                    setBottomConstraints(constraint: 600 - 441)
-                    setHeightConstraint(height: 600)
+                    setStoreInformationConstraints(
+                        heightConstraint: 600,
+                        bottomConstraint: 600 - 441,
+                        animated: true
+                    )
                     storeInformationView.changeToDetail()
                 } else {
-                    setBottomConstraints(constraint: -16)
-                    setHeightConstraint(height: storeInformationOriginalHeight)
+                    setStoreInformationConstraints(
+                        heightConstraint: storeInformationOriginalHeight,
+                        bottomConstraint: -16,
+                        animated: true
+                    )
                     storeInformationView.changeToSummary()
                 }
             })
@@ -227,8 +249,11 @@ final class HomeViewController: UIViewController {
             .subscribe(onNext: {[weak self] recognizer in
                 guard let self = self else { return }
                 if storeInformationHeightConstraint.constant == storeInformationOriginalHeight {
-                    setBottomConstraints(constraint: 600 - 441)
-                    setHeightConstraint(height: 600)
+                    setStoreInformationConstraints(
+                        heightConstraint: 600,
+                        bottomConstraint: 600 - 441,
+                        animated: true
+                    )
                     storeInformationView.changeToDetail()
                 }
             })
@@ -305,8 +330,11 @@ private extension HomeViewController {
         
         summaryInformationHeightObserver.bind { [weak self] height in
             self?.storeInformationOriginalHeight = height
-            self?.setBottomConstraints(constraint: -16)
-            self?.setHeightConstraint(height: height)
+            self?.setStoreInformationConstraints(
+                heightConstraint: height,
+                bottomConstraint: -16,
+                animated: true
+            )
             self?.storeInformationView.changeToSummary()
         }
         .disposed(by: disposeBag)
@@ -374,23 +402,22 @@ private extension HomeViewController {
     func storeInformationViewDismiss() {
         clickedMarker?.isSelected = false
         clickedMarker = nil
-        setBottomConstraints(constraint: -37)
-        setHeightConstraint(height: 0)
+        setStoreInformationConstraints(
+            heightConstraint: 0,
+            bottomConstraint: -37,
+            animated: true
+        )
         storeInformationView.dismissAll()
     }
     
-    func setBottomConstraints(constraint: CGFloat) {
-        locationButtonBottomConstraint.constant = constraint
-        refreshButtonBottomConstraint.constant = constraint
-        UIView.animate(withDuration: 0.3) { [weak self] in
-            self?.view.layoutIfNeeded()
-        }
-    }
-    
-    func setHeightConstraint(height: CGFloat) {
-        storeInformationHeightConstraint.constant = height
-        UIView.animate(withDuration: 0.3) { [weak self] in
-            self?.view.layoutIfNeeded()
+    func setStoreInformationConstraints(heightConstraint: CGFloat, bottomConstraint: CGFloat, animated: Bool = false) {
+        locationButtonBottomConstraint.constant = bottomConstraint
+        refreshButtonBottomConstraint.constant = bottomConstraint
+        storeInformationHeightConstraint.constant = heightConstraint
+        if animated {
+            UIView.animate(withDuration: 0.3) { [weak self] in
+                self?.view.layoutIfNeeded()
+            }
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -187,8 +187,10 @@ final class HomeViewController: UIViewController {
                 
                 if storeInformationHeightConstraint.constant > 420 {
                     // TODO: 441은 420에서 bottomSafeArea 길이인 21만큼 더해준 값이다.
+                    storeInformationView.changeToDetail()
                     setBottomConstraints(constraint: storeInformationHeightConstraint.constant - 441)
                 } else {
+                    storeInformationView.changeToSummary()
                     setBottomConstraints(constraint: -16)
                 }
             })
@@ -201,17 +203,21 @@ final class HomeViewController: UIViewController {
                 if recognizer.velocity(in: view).y < -1000 {
                     setBottomConstraints(constraint: 600 - 441)
                     setHeightConstraint(height: 600)
+                    storeInformationView.changeToDetail()
                 } else if recognizer.velocity(in: view).y > 1000 {
                     setBottomConstraints(constraint: -16)
                     setHeightConstraint(height: storeInformationOriginalHeight)
+                    storeInformationView.changeToSummary()
                 }
                 
                 if storeInformationHeightConstraint.constant > 420 {
                     setBottomConstraints(constraint: 600 - 441)
                     setHeightConstraint(height: 600)
+                    storeInformationView.changeToDetail()
                 } else {
                     setBottomConstraints(constraint: -16)
                     setHeightConstraint(height: storeInformationOriginalHeight)
+                    storeInformationView.changeToSummary()
                 }
             })
             .disposed(by: disposeBag)
@@ -289,6 +295,7 @@ private extension HomeViewController {
             self?.storeInformationOriginalHeight = height
             self?.setBottomConstraints(constraint: -16)
             self?.setHeightConstraint(height: height)
+            self?.storeInformationView.changeToSummary()
         }
         .disposed(by: disposeBag)
     
@@ -357,6 +364,7 @@ private extension HomeViewController {
         clickedMarker = nil
         setBottomConstraints(constraint: -37)
         setHeightConstraint(height: 0)
+        storeInformationView.dismissAll()
     }
     
     func setBottomConstraints(constraint: CGFloat) {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -246,7 +246,7 @@ final class HomeViewController: UIViewController {
         
         view.rx.tapGesture()
             .when(.ended)
-            .subscribe(onNext: {[weak self] _ in
+            .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 if storeInformationHeightConstraint.constant == storeInformationOriginalHeight {
                     setStoreInformationConstraints(

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -222,6 +222,18 @@ final class HomeViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        view.rx.tapGesture()
+            .when(.ended)
+            .subscribe(onNext: {[weak self] recognizer in
+                guard let self = self else { return }
+                if storeInformationHeightConstraint.constant == storeInformationOriginalHeight {
+                    setBottomConstraints(constraint: 600 - 441)
+                    setHeightConstraint(height: 600)
+                    storeInformationView.changeToDetail()
+                }
+            })
+            .disposed(by: disposeBag)
+        
         return view
     }()
     

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -23,9 +23,23 @@ final class StoreInformationView: UIView {
     private let summaryViewModel: SummaryInformationViewModel
     private let summaryInformationHeightObserver: PublishRelay<CGFloat>
     
-    init(summaryViewModel: SummaryInformationViewModel, summaryInformationHeightObserver: PublishRelay<CGFloat>) {
+    private lazy var detailView: DetailView = {
+        let view = DetailView(viewModel: detailViewModel)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let detailViewModel: DetailViewModel
+    
+    init(
+        summaryViewModel: SummaryInformationViewModel,
+        summaryInformationHeightObserver: PublishRelay<CGFloat>,
+        detailViewModel: DetailViewModel
+    ) {
         self.summaryViewModel = summaryViewModel
         self.summaryInformationHeightObserver = summaryInformationHeightObserver
+        self.detailViewModel = detailViewModel
         super.init(frame: .zero)
         
         addUIComponents()
@@ -42,6 +56,17 @@ extension StoreInformationView {
     
     func setUIContents(store: Store) {
         summaryView.setUIContents(store: store)
+        detailView.setUIContents(store: store)
+    }
+    
+    func changeToSummary() {
+        summaryView.isHidden = false
+        summaryView.isHidden = true
+    }
+    
+    func changeToDetail() {
+        summaryView.isHidden = true
+        summaryView.isHidden = false
     }
     
 }
@@ -50,6 +75,7 @@ private extension StoreInformationView {
     
     func addUIComponents() {
         addSubview(summaryView)
+        addSubview(detailView)
     }
     
     func configureConstraints() {
@@ -59,6 +85,13 @@ private extension StoreInformationView {
             summaryView.bottomAnchor.constraint(equalTo: bottomAnchor),
             summaryView.leadingAnchor.constraint(equalTo: leadingAnchor),
             summaryView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            detailView.topAnchor.constraint(equalTo: topAnchor),
+            detailView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            detailView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            detailView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
         
     }

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -46,7 +46,7 @@ final class StoreInformationView: UIView {
         setBackgroundColor()
         addUIComponents()
         configureConstraints()
-        changeToSummary()
+        dismissAll()
     }
     
     required init?(coder: NSCoder) {

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -42,8 +42,10 @@ final class StoreInformationView: UIView {
         self.detailViewModel = detailViewModel
         super.init(frame: .zero)
         
+        setBackgroundColor()
         addUIComponents()
         configureConstraints()
+        changeToSummary()
     }
     
     required init?(coder: NSCoder) {
@@ -60,18 +62,39 @@ extension StoreInformationView {
     }
     
     func changeToSummary() {
-        summaryView.isHidden = false
-        summaryView.isHidden = true
+        summaryView.isUserInteractionEnabled = true
+        detailView.isUserInteractionEnabled = false
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.summaryView.alpha = 1
+            self?.detailView.alpha = 0
+        }
     }
     
     func changeToDetail() {
-        summaryView.isHidden = true
-        summaryView.isHidden = false
+        summaryView.isUserInteractionEnabled = false
+        detailView.isUserInteractionEnabled = true
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.summaryView.alpha = 0
+            self?.detailView.alpha = 1
+        }
+    }
+    
+    func dismissAll() {
+        summaryView.isUserInteractionEnabled = false
+        detailView.isUserInteractionEnabled = false
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.summaryView.alpha = 0
+            self?.detailView.alpha = 0
+        }
     }
     
 }
 
 private extension StoreInformationView {
+    
+    func setBackgroundColor() {
+        backgroundColor = .white
+    }
     
     func addUIComponents() {
         addSubview(summaryView)

--- a/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/StoreInformationView.swift
@@ -42,6 +42,7 @@ final class StoreInformationView: UIView {
         self.detailViewModel = detailViewModel
         super.init(frame: .zero)
         
+        setLayerCorner(cornerRadius: 15, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         setBackgroundColor()
         addUIComponents()
         configureConstraints()

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -221,7 +221,7 @@ extension SummaryInformationView {
         if let url = store.localPhotos.first {
             viewModel.action(input: .setInformationView(
                 openingHour: store.openingHour,
-                url: store.localPhotos.first)
+                url: url)
             )
         } else {
             storeImageView.image = UIImage.basicStore

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// TODO: 디자인과 기능 스펙이 정해지면 수정해야 합니다.
 final class DetailViewModelImpl: DetailViewModel {
     
     func action(input: DetailViewModelInputCase) {

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -1,0 +1,16 @@
+//
+//  DetailViewModelImpl.swift
+//  KCS
+//
+//  Created by 조성민 on 1/24/24.
+//
+
+import Foundation
+
+struct DetailViewModelImpl: DetailViewModel {
+    
+    func action(input: DetailViewModelInputCase) {
+        
+    }
+    
+}

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DetailViewModelImpl: DetailViewModel {
+final class DetailViewModelImpl: DetailViewModel {
     
     func action(input: DetailViewModelInputCase) {
         

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// TODO: 디자인과 기능 스펙이 정해지면 수정해야 합니다.
 protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {
     
     init()

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  DetailViewModel.swift
+//  KCS
+//
+//  Created by 조성민 on 1/24/24.
+//
+
+import Foundation
+
+protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {
+    
+    init()
+    
+}
+
+enum DetailViewModelInputCase {
+    
+}
+
+protocol DetailViewModelInput {
+    
+    func action(input: DetailViewModelInputCase)
+    
+}
+
+protocol DetailViewModelOutput {
+    
+}

--- a/KCS/Podfile
+++ b/KCS/Podfile
@@ -10,6 +10,7 @@ target 'KCS' do
    
   pod 'RxSwift', '6.6.0'
   pod 'RxCocoa', '6.6.0'
+  pod 'RxGesture'
   pod 'Alamofire'
   pod 'SwiftLint'
   pod 'NMapsMap'

--- a/KCS/Podfile.lock
+++ b/KCS/Podfile.lock
@@ -8,6 +8,9 @@ PODS:
   - RxCocoa (6.6.0):
     - RxRelay (= 6.6.0)
     - RxSwift (= 6.6.0)
+  - RxGesture (4.0.4):
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - RxRelay (6.6.0):
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
@@ -20,6 +23,7 @@ DEPENDENCIES:
   - NMapsMap
   - RxBlocking
   - RxCocoa (= 6.6.0)
+  - RxGesture
   - RxSwift (= 6.6.0)
   - RxTest
   - SwiftLint
@@ -31,6 +35,7 @@ SPEC REPOS:
     - NMapsMap
     - RxBlocking
     - RxCocoa
+    - RxGesture
     - RxRelay
     - RxSwift
     - RxTest
@@ -42,11 +47,12 @@ SPEC CHECKSUMS:
   NMapsMap: a5b909a31b6f3d27a670f6eb2ddc913c38975474
   RxBlocking: fbd1f8501443024f686e556f36dac79b0d5f4d7c
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
+  RxGesture: f3efb47ed2d26a8082f7b660d4a59970e275a7f8
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   RxTest: a23f26bb53a5e146a0a69db4f0fa0b69001ce7f4
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 0f88675320ac9cb6ad8c84bdece01c7160cd9d79
+PODFILE CHECKSUM: 529859231e49f63fa881147a916b977cb8f574df
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
## ⭐️ Issue Number

- #111

## 🚩 Summary

- DetailView 틀 잡기
- DetailViewModel 포함하여 DetailView StoreInformationView에 추가
- Gesture에 따라 View 전환 구현 

![Simulator Screen Recording - iPhone 15 Pro - 2024-01-24 at 21 28 02](https://github.com/Korea-Certified-Store/iOS/assets/128480641/aca0274b-cfd9-41ec-afe7-9078e59c14f5)

## 🛠️ Technical Concerns

### 리스트 구현을 염두하는 설계

SummaryView가 있는 상태에서 DetailView로 넘어가는 경우만 있는 것이 아니다.
추후에 추가될 리스트에서 Cell을 선택했을 때, DetailView로 올 수 있기 때문에 염두하에 컨트롤 할 수 있는 함수를 StoreInformationView에 구현했다.
```swift
func changeToSummary() {
    summaryView.isUserInteractionEnabled = true
    detailView.isUserInteractionEnabled = false
    UIView.animate(withDuration: 0.3) { [weak self] in
        self?.summaryView.alpha = 1
        self?.detailView.alpha = 0
    }
}

func changeToDetail() {
    summaryView.isUserInteractionEnabled = false
    detailView.isUserInteractionEnabled = true
    UIView.animate(withDuration: 0.3) { [weak self] in
        self?.summaryView.alpha = 0
        self?.detailView.alpha = 1
    }
}

func dismissAll() {
    summaryView.isUserInteractionEnabled = false
    detailView.isUserInteractionEnabled = false
    UIView.animate(withDuration: 0.3) { [weak self] in
        self?.summaryView.alpha = 0
        self?.detailView.alpha = 0
    }
}
```

## 📋 To Do

- ViewController에 로직이 추가되는 경우가 많다. 
리팩토링을 통해서 ViewModel 혹은 UseCase로 옮기는 작업이 필수적이다.