### PR TITLE
위치 서비스가 꺼져있는 경우 현위치 버튼 회색

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -513,7 +513,12 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
         if reason == NMFMapChangedByDeveloper {
             mapView.positionMode = .direction
-            locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
+            let authorizationStatus = locationManager.authorizationStatus
+            if authorizationStatus == .denied || authorizationStatus == .restricted || authorizationStatus == .notDetermined {
+                locationButton.setImage(UIImage.locationButtonNone, for: .normal)
+            } else {
+                locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
+            }
             
             let northWestPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: 0))
             let southWestPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: view.frame.height))

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -519,7 +519,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             case .authorizedWhenInUse:
                 locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
             default:
-                return
+                break
             }
             
             let northWestPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: 0))

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -513,11 +513,13 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
         if reason == NMFMapChangedByDeveloper {
             mapView.positionMode = .direction
-            let authorizationStatus = locationManager.authorizationStatus
-            if authorizationStatus == .denied || authorizationStatus == .restricted || authorizationStatus == .notDetermined {
+            switch locationManager.authorizationStatus {
+            case .denied, .restricted, .notDetermined:
                 locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-            } else {
+            case .authorizedWhenInUse:
                 locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
+            default:
+                return
             }
             
             let northWestPoint = mapView.projection.latlng(from: CGPoint(x: 0, y: 0))


### PR DESCRIPTION
## ⭐️ Issue Number

- #115 

## 🚩 Summary

- 위치 권한이 주어지지 않았을 때 현위치 버튼의 이미지 오류를 수정하였다.

<img src="https://github.com/Korea-Certified-Store/iOS/assets/62226667/7631629e-f822-413a-a23f-8b682433f873" width=400 height=840>
