### PR TITLE
상세 정보 UIView 오류 수정

### DIFF
--- a/KCS/KCS/Domain/Entity/DetailViewContents.swift
+++ b/KCS/KCS/Domain/Entity/DetailViewContents.swift
@@ -1,0 +1,20 @@
+//
+//  DetailViewContents.swift
+//  KCS
+//
+//  Created by 김영현 on 1/27/24.
+//
+
+import Foundation
+
+struct DetailViewContents {
+    
+    let storeTitle: String
+    let category: String?
+    let certificationTypes: [CertificationType]
+    let address: String
+    let phoneNumber: String
+    let openClosedContent: OpenClosedContent
+    let detailOpeningHour: [DetailOpeningHour]
+    
+}

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -140,6 +140,7 @@ final class DetailView: UIView {
     
     private let viewModel: DetailViewModel
     private lazy var addressConstraint = address.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
+    private lazy var phoneNumberConstraint = phoneNumber.topAnchor.constraint(equalTo: openingHoursStackView.bottomAnchor, constant: 20)
     
     init(viewModel: DetailViewModel) {
         self.viewModel = viewModel
@@ -281,12 +282,12 @@ private extension DetailView {
         ])
         
         NSLayoutConstraint.activate([
-            phoneNumber.topAnchor.constraint(equalTo: openingHoursStackView.bottomAnchor, constant: 20),
-            phoneNumber.leadingAnchor.constraint(equalTo: phoneIcon.trailingAnchor, constant: 11)
+            phoneNumber.leadingAnchor.constraint(equalTo: phoneIcon.trailingAnchor, constant: 11),
+            phoneNumberConstraint
         ])
         
         NSLayoutConstraint.activate([
-            addressIcon.centerYAnchor.constraint(equalTo: address.centerYAnchor),
+            addressIcon.topAnchor.constraint(equalTo: address.topAnchor),
             addressIcon.leadingAnchor.constraint(equalTo: clockIcon.leadingAnchor),
             addressIcon.heightAnchor.constraint(equalToConstant: 16),
             addressIcon.widthAnchor.constraint(equalToConstant: 11)
@@ -320,11 +321,13 @@ private extension DetailView {
             storeOpenClosed.textColor = .black
             openingHour.text = openClosedContent.openClosedType.rawValue
             addressConstraint.constant = -174
+            phoneNumberConstraint.constant = 20 - 11
         } else {
             storeOpenClosed.text = openClosedContent.openClosedType.rawValue
             storeOpenClosed.textColor = UIColor.goodPrice
             openingHour.text = openClosedContent.nextOpeningHour
             addressConstraint.constant = -16
+            phoneNumberConstraint.constant = 20
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -71,6 +71,7 @@ final class DetailView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
+        label.textColor = .black
         
         return label
     }()
@@ -106,6 +107,7 @@ final class DetailView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
+        label.textColor = .black
         
         return label
     }()
@@ -121,6 +123,7 @@ final class DetailView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
+        label.textColor = .black
         label.numberOfLines = 0
         
         return label
@@ -171,8 +174,9 @@ private extension DetailView {
                 let openClosedContent = openClosedInformation.openClosedContent
                 setOpeningHourText(openClosedContent: openClosedContent)
                 
-                var detailOpeningHour = openClosedInformation.detailOpeningHour
-                let today = detailOpeningHour.removeFirst()
+                var detailOpeningHours = openClosedInformation.detailOpeningHour
+                if detailOpeningHours.isEmpty { return }
+                let today = detailOpeningHours.removeFirst()
                 openingHoursStackView.addArrangedSubview(
                     OpeningHoursCellView(
                         weekday: today.weekDay,
@@ -180,7 +184,7 @@ private extension DetailView {
                         isToday: true
                     )
                 )
-                openClosedInformation.detailOpeningHour.forEach { [weak self] detailOpeningHour in
+                detailOpeningHours.forEach { [weak self] detailOpeningHour in
                     self?.openingHoursStackView.addArrangedSubview(
                         OpeningHoursCellView(
                             weekday: detailOpeningHour.weekDay,

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -349,11 +349,9 @@ extension DetailView {
         } else {
             phoneNumber.text = "전화번호 정보 없음"
         }
+        viewModel.action(input: .setOpeningHour(openingHour: store.openingHour))
         if let url = store.localPhotos.first {
-            viewModel.action(input: .setInformationView(
-                openingHour: store.openingHour,
-                url: url)
-            )
+            viewModel.action(input: .setImageView(url: url))
         } else {
             storeImageView.image = UIImage.basicStore
         }

--- a/KCS/KCS/Presentation/Home/View/OpeningHoursCellView.swift
+++ b/KCS/KCS/Presentation/Home/View/OpeningHoursCellView.swift
@@ -17,6 +17,7 @@ final class OpeningHoursCellView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = weekday.description
+        label.textColor = .black
         if isToday {
             label.font = UIFont.pretendard(size: 13, weight: .medium)
         } else {
@@ -30,6 +31,7 @@ final class OpeningHoursCellView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = openingHour.openingHour
+        label.textColor = .black
         if isToday {
             label.font = UIFont.pretendard(size: 12, weight: .medium)
         } else {
@@ -43,6 +45,7 @@ final class OpeningHoursCellView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = openingHour.breakTime
+        label.textColor = .black
         if isToday {
             label.font = UIFont.pretendard(size: 12, weight: .medium)
         } else {

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -25,11 +25,12 @@ final class DetailViewModelImpl: DetailViewModel {
     
     func action(input: DetailViewModelInputCase) {
         switch input {
-        case .setInformationView(let openingHour, let url):
-            setOpenClosed(openingHour: openingHour)
+        case .setImageView(let url):
             if let url = url {
                 fetchThumbnailImage(url: url)
             }
+        case .setOpeningHour(let openingHour):
+            setOpenClosed(openingHour: openingHour)
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -17,8 +17,7 @@ protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {
 
 enum DetailViewModelInputCase {
     
-    case setImageView(url: String?)
-    case setOpeningHour(openingHour: [RegularOpeningHours])
+    case setUIContents(store: Store)
     
 }
 
@@ -29,6 +28,8 @@ protocol DetailViewModelInput {
 }
 
 protocol DetailViewModelOutput {
-    var openClosedOutput: PublishRelay<OpeningHourInformation> { get }
+    
+    var setUIContentsOutput: PublishRelay<DetailViewContents> { get }
     var thumbnailImageOutput: PublishRelay<Data> { get }
+    
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -18,8 +18,8 @@ protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {
 enum DetailViewModelInputCase {
     
     case setImageView(url: String?)
-    
     case setOpeningHour(openingHour: [RegularOpeningHours])
+    
 }
 
 protocol DetailViewModelInput {

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -17,10 +17,9 @@ protocol DetailViewModel: DetailViewModelInput, DetailViewModelOutput {
 
 enum DetailViewModelInputCase {
     
-    case setInformationView(
-        openingHour: [RegularOpeningHours],
-        url: String?
-    )
+    case setImageView(url: String?)
+    
+    case setOpeningHour(openingHour: [RegularOpeningHours])
 }
 
 protocol DetailViewModelInput {


### PR DESCRIPTION
## ⭐️ Issue Number

- #119 

## 🚩 Summary

- 시간 정보 예외 처리
- Label 색상 black으로 통일
- DetailViewModel의 input, output 수정

## 🛠️ Technical Concerns

### ViewModel의 Input, Output에 대한 고민

ViewModel의 input은 viewDidLoad라는 하나의 값으로 들어오게 되는데, output의 경우 영업 시간에 대한 output, 사진에 대한 output 이렇게 두 개를 반환하고 있었다. 하지만 하나의 output에서 UI에 세팅될 모든 값에 대한 로직 처리를 ViewModel에서 하면 훨씬 효율적이고 이 방법이 MVVM에 더 맞는 방법인 것 같아 output을 영업 시간 뿐만 아니라 화면에 세팅되는 모든 값을 처리해 주도록 변경하였다.

## 📋 To Do

- 추후 OpeningHourInformation entity의 수정이 필요합니다.
- StackView의 메모리 해제를 위한 removeStackView함수를 UIStackView의 extension으로 수정해야합니다.
