### PR TITLE
Error Alert

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 		A8ACB7ED2B59647400540BD1 /* OpeningHourError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */; };
 		A8ACB7EF2B5AEBB900540BD1 /* GetStoreInformationUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7EE2B5AEBB800540BD1 /* GetStoreInformationUseCaseImpl.swift */; };
 		A8ACB7F12B5AEBE300540BD1 /* GetStoreInformationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */; };
-		A8AE4B192B62903100632355 /* OpeningHourViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B182B62903100632355 /* OpeningHourViewModel.swift */; };
 		A8AE4B1B2B62A60B00632355 /* OpeningHoursCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
@@ -201,7 +200,6 @@
 		A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHourError.swift; sourceTree = "<group>"; };
 		A8ACB7EE2B5AEBB800540BD1 /* GetStoreInformationUseCaseImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCaseImpl.swift; sourceTree = "<group>"; };
 		A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCase.swift; sourceTree = "<group>"; };
-		A8AE4B182B62903100632355 /* OpeningHourViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHourViewModel.swift; sourceTree = "<group>"; };
 		A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursCellView.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -294,7 +292,6 @@
 				5977BE672B553C8300725C90 /* HomeDependency.swift */,
 				A8ACB7E12B594F7400540BD1 /* SummaryViewModelImpl.swift */,
 				592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */,
-				A8AE4B182B62903100632355 /* OpeningHourViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -844,7 +841,6 @@
 				59C306CB2B50357900862625 /* Router.swift in Sources */,
 				A8ACB7E82B595A2100540BD1 /* GetOpenClosedUseCase.swift in Sources */,
 				59C306B62B50027300862625 /* Store.swift in Sources */,
-				A8AE4B192B62903100632355 /* OpeningHourViewModel.swift in Sources */,
 				59C306B42B50015500862625 /* APIResponse.swift in Sources */,
 				A8A7E0622B652F0D00D015E5 /* MarkerContents.swift in Sources */,
 				5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		59F478BD2B5AE180002FEF9E /* FetchStoresUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478BC2B5AE180002FEF9E /* FetchStoresUseCaseImplTests.swift */; };
 		59F478BF2B5BEA08002FEF9E /* RequestLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478BE2B5BEA08002FEF9E /* RequestLocation.swift */; };
 		59F478C12B5D0D8D002FEF9E /* ImageRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F478C02B5D0D8D002FEF9E /* ImageRepositoryImplTests.swift */; };
-		8FE699E5DAEEDFE5A53D5E82 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */; };
 		A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A802D1F52B5277620091FDE7 /* CertificationLabel.swift */; };
 		A81EFBB32B5BC57800D0C0D7 /* OpenClosedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBB22B5BC57800D0C0D7 /* OpenClosedContent.swift */; };
 		A81EFBB52B5D477600D0C0D7 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBB42B5D477600D0C0D7 /* UILabel+.swift */; };
@@ -93,7 +92,8 @@
 		A8ACB7F12B5AEBE300540BD1 /* GetStoreInformationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */; };
 		A8AE4B192B62903100632355 /* OpeningHourViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B182B62903100632355 /* OpeningHourViewModel.swift */; };
 		A8AE4B1B2B62A60B00632355 /* OpeningHoursCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */; };
-		F242B43374CDD61CC6F6A4D5 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FF39E6207057AD78DB44730 /* Pods_KCSUnitTest.framework */; };
+		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
+		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,8 +107,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0FF39E6207057AD78DB44730 /* Pods_KCSUnitTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KCSUnitTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4BD0CCD4DBD4E121C26925E6 /* Pods-KCSUnitTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.release.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.release.xcconfig"; sourceTree = "<group>"; };
+		2A59B3837A53AAB2D7A1E09C /* Pods-KCSUnitTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.release.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.release.xcconfig"; sourceTree = "<group>"; };
 		59053D0A2B3889A200D190CC /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		591A88792B384E600059E40F /* KCS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KCS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		591A887C2B384E600059E40F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -164,8 +163,10 @@
 		59F478BC2B5AE180002FEF9E /* FetchStoresUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoresUseCaseImplTests.swift; sourceTree = "<group>"; };
 		59F478BE2B5BEA08002FEF9E /* RequestLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocation.swift; sourceTree = "<group>"; };
 		59F478C02B5D0D8D002FEF9E /* ImageRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryImplTests.swift; sourceTree = "<group>"; };
-		5FF0FF2386EEB69182D6EA4C /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
-		9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.debug.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.debug.xcconfig"; sourceTree = "<group>"; };
+		5A3902FBE673069073F47D82 /* Pods_KCS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KCS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E7A587B8D04F1EBD1715550 /* Pods-KCS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.release.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.release.xcconfig"; sourceTree = "<group>"; };
+		71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KCSUnitTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		96F7AFBA49BAE4D780F6D753 /* Pods-KCS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.debug.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.debug.xcconfig"; sourceTree = "<group>"; };
 		A802D1F52B5277620091FDE7 /* CertificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificationLabel.swift; sourceTree = "<group>"; };
 		A81EFBB22B5BC57800D0C0D7 /* OpenClosedContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClosedContent.swift; sourceTree = "<group>"; };
 		A81EFBB42B5D477600D0C0D7 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
@@ -200,8 +201,7 @@
 		A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCase.swift; sourceTree = "<group>"; };
 		A8AE4B182B62903100632355 /* OpeningHourViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHourViewModel.swift; sourceTree = "<group>"; };
 		A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursCellView.swift; sourceTree = "<group>"; };
-		AA9EF30352C847A7C6DEC110 /* Pods-KCS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCS.release.xcconfig"; path = "Target Support Files/Pods-KCS/Pods-KCS.release.xcconfig"; sourceTree = "<group>"; };
-		E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KCS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -209,7 +209,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8FE699E5DAEEDFE5A53D5E82 /* Pods_KCS.framework in Frameworks */,
+				BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,7 +217,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F242B43374CDD61CC6F6A4D5 /* Pods_KCSUnitTest.framework in Frameworks */,
+				AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,7 +233,7 @@
 				5977BE8B2B5966F900725C90 /* KCSUnitTest */,
 				591A887A2B384E600059E40F /* Products */,
 				ED50AD730FA5F4D533F6DF5F /* Pods */,
-				CBA0F2F7C6731F98AFE4E86D /* Frameworks */,
+				E99F20FF9A30DCF9C51285A2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -561,11 +561,11 @@
 			path = Error;
 			sourceTree = "<group>";
 		};
-		CBA0F2F7C6731F98AFE4E86D /* Frameworks */ = {
+		E99F20FF9A30DCF9C51285A2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E11E3144529848C9A0FC6F77 /* Pods_KCS.framework */,
-				0FF39E6207057AD78DB44730 /* Pods_KCSUnitTest.framework */,
+				5A3902FBE673069073F47D82 /* Pods_KCS.framework */,
+				71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -573,10 +573,10 @@
 		ED50AD730FA5F4D533F6DF5F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */,
-				AA9EF30352C847A7C6DEC110 /* Pods-KCS.release.xcconfig */,
-				5FF0FF2386EEB69182D6EA4C /* Pods-KCSUnitTest.debug.xcconfig */,
-				4BD0CCD4DBD4E121C26925E6 /* Pods-KCSUnitTest.release.xcconfig */,
+				96F7AFBA49BAE4D780F6D753 /* Pods-KCS.debug.xcconfig */,
+				6E7A587B8D04F1EBD1715550 /* Pods-KCS.release.xcconfig */,
+				D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */,
+				2A59B3837A53AAB2D7A1E09C /* Pods-KCSUnitTest.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -588,12 +588,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 591A888D2B384E610059E40F /* Build configuration list for PBXNativeTarget "KCS" */;
 			buildPhases = (
-				CB55E62BB6C1E559A1B678AA /* [CP] Check Pods Manifest.lock */,
+				1710AC2AA053B9D767B25C83 /* [CP] Check Pods Manifest.lock */,
 				591A88752B384E600059E40F /* Sources */,
 				591A88762B384E600059E40F /* Frameworks */,
 				591A88772B384E600059E40F /* Resources */,
-				3BC1B94F5FD0808C2E71C0CF /* [CP] Embed Pods Frameworks */,
 				591A88902B3884930059E40F /* Run Script */,
+				C9DF99EE5FF9433DE46D74ED /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -608,11 +608,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5977BE922B5966F900725C90 /* Build configuration list for PBXNativeTarget "KCSUnitTest" */;
 			buildPhases = (
-				B40FA4C5FEA2CEF5D14076EF /* [CP] Check Pods Manifest.lock */,
+				A73C3D34B606A83DF89A57DD /* [CP] Check Pods Manifest.lock */,
 				5977BE862B5966F900725C90 /* Sources */,
 				5977BE872B5966F900725C90 /* Frameworks */,
 				5977BE882B5966F900725C90 /* Resources */,
-				BC4E38BB9B3B1281AC2576D1 /* [CP] Embed Pods Frameworks */,
+				4A3D260580D318595657BED8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -693,21 +693,43 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BC1B94F5FD0808C2E71C0CF /* [CP] Embed Pods Frameworks */ = {
+		1710AC2AA053B9D767B25C83 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-KCS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4A3D260580D318595657BED8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		591A88902B3884930059E40F /* Run Script */ = {
@@ -729,7 +751,7 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
-		B40FA4C5FEA2CEF5D14076EF /* [CP] Check Pods Manifest.lock */ = {
+		A73C3D34B606A83DF89A57DD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -751,43 +773,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BC4E38BB9B3B1281AC2576D1 /* [CP] Embed Pods Frameworks */ = {
+		C9DF99EE5FF9433DE46D74ED /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CB55E62BB6C1E559A1B678AA /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-KCS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KCS/Pods-KCS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1024,7 +1024,7 @@
 		};
 		591A888E2B384E610059E40F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9EA5C8EA72EA9E937C11400A /* Pods-KCS.debug.xcconfig */;
+			baseConfigurationReference = 96F7AFBA49BAE4D780F6D753 /* Pods-KCS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1059,7 +1059,7 @@
 		};
 		591A888F2B384E610059E40F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AA9EF30352C847A7C6DEC110 /* Pods-KCS.release.xcconfig */;
+			baseConfigurationReference = 6E7A587B8D04F1EBD1715550 /* Pods-KCS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1094,7 +1094,7 @@
 		};
 		5977BE902B5966F900725C90 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5FF0FF2386EEB69182D6EA4C /* Pods-KCSUnitTest.debug.xcconfig */;
+			baseConfigurationReference = D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1119,7 +1119,7 @@
 		};
 		5977BE912B5966F900725C90 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BD0CCD4DBD4E121C26925E6 /* Pods-KCSUnitTest.release.xcconfig */;
+			baseConfigurationReference = 2A59B3837A53AAB2D7A1E09C /* Pods-KCSUnitTest.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		592262242B61203000CA5A11 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262232B61203000CA5A11 /* DetailView.swift */; };
 		592262262B61232F00CA5A11 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262252B61232F00CA5A11 /* DetailViewModel.swift */; };
 		592262282B6124C400CA5A11 /* DetailViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */; };
+		595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */; };
 		596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
 		5977BE5C2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE5B2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift */; };
@@ -119,6 +120,7 @@
 		592262232B61203000CA5A11 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		592262252B61232F00CA5A11 /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		592262272B6124C400CA5A11 /* DetailViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModelImpl.swift; sourceTree = "<group>"; };
+		595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertMessage.swift; sourceTree = "<group>"; };
 		596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewContents.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
 		5977BE5B2B5535A100725C90 /* FetchRefreshStoresUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRefreshStoresUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -427,6 +429,7 @@
 				596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */,
 				A8A7E05A2B642EC900D015E5 /* DetailViewContents.swift */,
 				A8A7E0612B652F0D00D015E5 /* MarkerContents.swift */,
+				595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -802,6 +805,7 @@
 				A890870F2B4F836C00767225 /* SummaryInformationView.swift in Sources */,
 				A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */,
 				5977BE612B55374000725C90 /* HomeViewModel.swift in Sources */,
+				595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */,
 				A8AE4B1B2B62A60B00632355 /* OpeningHoursCellView.swift in Sources */,
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
 				59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */,

--- a/KCS/KCS/Data/Network/DTO/StoreDTO.swift
+++ b/KCS/KCS/Data/Network/DTO/StoreDTO.swift
@@ -33,25 +33,19 @@ struct StoreDTO: Codable {
         
     }
     
-    func toEntity() -> Store {
+    func toEntity() throws -> Store {
         var certificationTypes: [CertificationType] = []
         var openingHours: [RegularOpeningHours] = []
         
-        do {
-            for name in certificationName {
-                guard let type = CertificationType(rawValue: name) else {
-                    throw JSONContentsError.wrongCertificationType
-                }
-                certificationTypes.append(type)
+        for name in certificationName {
+            guard let type = CertificationType(rawValue: name) else {
+                throw JSONContentsError.wrongCertificationType
             }
-            
-            for hour in regularOpeningHours {
-                openingHours.append(try hour.toEntity())
-            }
-        } catch let error as JSONContentsError {
-            print(error.errorDescription)
-        } catch let error {
-            print(error.localizedDescription)
+            certificationTypes.append(type)
+        }
+        
+        for hour in regularOpeningHours {
+            openingHours.append(try hour.toEntity())
         }
         
         return Store(

--- a/KCS/KCS/Data/Network/Error/NetworkError.swift
+++ b/KCS/KCS/Data/Network/Error/NetworkError.swift
@@ -10,11 +10,14 @@ import Foundation
 enum NetworkError: Error, LocalizedError {
     
     case wrongURL
+    case wrongParameters
     
     var errorDescription: String {
         switch self {
         case .wrongURL:
             return "URL이 잘못되었습니다."
+        case .wrongParameters:
+            return "Parameters가 잘못되었습니다."
         }
     }
     

--- a/KCS/KCS/Data/Network/Extension/Encodable+.swift
+++ b/KCS/KCS/Data/Network/Extension/Encodable+.swift
@@ -11,7 +11,10 @@ extension Encodable {
     
     func asDictionary() throws -> [String: Any] {
         let data = try JSONEncoder().encode(self)
-        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
+        guard let dictionary = try JSONSerialization.jsonObject(
+            with: data,
+            options: .allowFragments
+        ) as? [String: Any] else {
             throw JSONContentsError.dictionaryConvert
         }
         return dictionary

--- a/KCS/KCS/Data/Network/Router.swift
+++ b/KCS/KCS/Data/Network/Router.swift
@@ -9,7 +9,7 @@ import Alamofire
 
 protocol Router {
     
-    var baseURL: String { get }
+    var baseURL: String? { get }
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: [String: String] { get }

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -16,36 +16,31 @@ enum StoreAPI {
 }
 
 extension StoreAPI: Router, URLRequestConvertible {
-
-    public var baseURL: String {
+    
+    var baseURL: String? {
         switch self {
         case .getStores:
-            do {
-                return try getURL(type: .develop)
-            } catch {
-                print(error.localizedDescription)
-                return ""
-            }
+            return getURL(type: .develop)
         case .getImage(let url):
             return url
         }
     }
     
-    public var path: String {
+    var path: String {
         switch self {
         case .getStores, .getImage:
             return ""
         }
     }
     
-    public var method: HTTPMethod {
+    var method: HTTPMethod {
         switch self {
         case .getStores, .getImage:
             return .get
         }
     }
     
-    public var headers: [String: String] {
+    var headers: [String: String] {
         switch self {
         case .getStores:
             return [
@@ -56,13 +51,13 @@ extension StoreAPI: Router, URLRequestConvertible {
         }
     }
     
-    public var parameters: [String: Any]? {
+    var parameters: [String: Any]? {
         do {
             switch self {
             case let .getStores(location):
                 return try location.asDictionary()
             case .getImage:
-                return nil
+                return [:]
             }
         } catch let error {
             print(error.localizedDescription)
@@ -72,7 +67,7 @@ extension StoreAPI: Router, URLRequestConvertible {
     
     /// 파라미터로 보내야할 것이 있다면, URLEncoding.default
     /// 바디에 담아서 보내야할 것이 있다면, JSONEncoding.default
-    public var encoding: ParameterEncoding? {
+    var encoding: ParameterEncoding? {
         switch self {
         case .getStores:
             return URLEncoding.default
@@ -81,8 +76,9 @@ extension StoreAPI: Router, URLRequestConvertible {
         }
     }
     
-    public func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
+    func asURLRequest() throws -> URLRequest {
+        guard let base = baseURL,
+              let url = URL(string: base + path) else {
             throw NetworkError.wrongURL
         }
         var request = URLRequest(url: url)
@@ -108,13 +104,13 @@ private extension StoreAPI {
         
     }
     
-    func getURL(type: URLType) throws -> String {
+    func getURL(type: URLType) -> String? {
         switch type {
         case .develop:
-            guard let url = Bundle.main.object(forInfoDictionaryKey: "DEV_SERVER_URL") as? String else { throw NetworkError.wrongURL }
+            guard let url = Bundle.main.object(forInfoDictionaryKey: "DEV_SERVER_URL") as? String else { return nil }
             return url
         case .product:
-            guard let url = Bundle.main.object(forInfoDictionaryKey: "PROD_SERVER_URL") as? String else { throw NetworkError.wrongURL }
+            guard let url = Bundle.main.object(forInfoDictionaryKey: "PROD_SERVER_URL") as? String else { return nil }
             return url
         }
     }

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -59,7 +59,7 @@ extension StoreAPI: Router, URLRequestConvertible {
             case .getImage:
                 return [:]
             }
-        } catch let error {
+        } catch {
             print(error.localizedDescription)
             return nil
         }
@@ -87,7 +87,11 @@ extension StoreAPI: Router, URLRequestConvertible {
         request.headers = HTTPHeaders(headers)
         
         if let encoding = encoding {
-            return try encoding.encode(request, with: parameters)
+            if let parameters = parameters {
+                return try encoding.encode(request, with: parameters)
+            } else {
+                throw NetworkError.wrongParameters
+            }
         }
         
         return request

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -60,7 +60,6 @@ extension StoreAPI: Router, URLRequestConvertible {
                 return [:]
             }
         } catch {
-            print(error.localizedDescription)
             return nil
         }
     }

--- a/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
@@ -28,7 +28,7 @@ struct ImageRepositoryImpl: ImageRepository {
                         .response(completionHandler: { response in
                             switch response.result {
                             case .success(let result):
-                                if let resultData = result {
+                                if let resultData = result, String(data: resultData, encoding: .utf8) == nil {
                                     cache.setImageData(resultData as NSData, for: imageURL as NSURL)
                                     observer.onNext(resultData)
                                 } else {

--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -40,7 +40,7 @@ final class StoreRepositoryImpl: StoreRepository {
                     case .failure(let error):
                         throw error
                     }
-                } catch let error {
+                } catch {
                     observer.onError(error)
                 }
             }

--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -31,16 +31,19 @@ final class StoreRepositoryImpl: StoreRepository {
                 neLat: requestLocation.northEast.latitude
             )))
             .responseDecodable(of: StoreResponse.self) { [weak self] response in
-                switch response.result {
-                case .success(let result):
-                    let resultStores = result.data.map { $0.toEntity() }
-                    self?.stores = resultStores
-                    observer.onNext(resultStores)
-                case .failure(let error):
+                do {
+                    switch response.result {
+                    case .success(let result):
+                        let resultStores = try result.data.map { try $0.toEntity() }
+                        self?.stores = resultStores
+                        observer.onNext(resultStores)
+                    case .failure(let error):
+                        throw error
+                    }
+                } catch let error {
                     observer.onError(error)
                 }
             }
-            
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Domain/Entity/ErrorAlertMessage.swift
+++ b/KCS/KCS/Domain/Entity/ErrorAlertMessage.swift
@@ -11,8 +11,8 @@ enum ErrorAlertMessage: LocalizedError {
     
     case server
     case data
-    
-    var errorDescription: String {
+     
+    var errorDescription: String? {
         switch self {
         case .server:
             return "서버와의 통신이 원활하지 않습니다"

--- a/KCS/KCS/Domain/Entity/ErrorAlertMessage.swift
+++ b/KCS/KCS/Domain/Entity/ErrorAlertMessage.swift
@@ -1,0 +1,24 @@
+//
+//  ErrorAlertMessage.swift
+//  KCS
+//
+//  Created by 조성민 on 1/30/24.
+//
+
+import Foundation
+
+enum ErrorAlertMessage: LocalizedError {
+    
+    case server
+    case data
+    
+    var errorDescription: String {
+        switch self {
+        case .server:
+            return "서버와의 통신이 원활하지 않습니다"
+        case .data:
+            return "데이터를 불러올 수 없습니다"
+        }
+    }
+    
+}

--- a/KCS/KCS/Domain/Interface/UseCase/GetOpenClosedUseCase.swift
+++ b/KCS/KCS/Domain/Interface/UseCase/GetOpenClosedUseCase.swift
@@ -11,6 +11,6 @@ protocol GetOpenClosedUseCase {
     
     func execute(
         openingHours: [RegularOpeningHours]
-    ) -> OpenClosedContent
+    ) throws -> OpenClosedContent
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -530,10 +530,11 @@ private extension HomeViewController {
     func presentErrorAlert(error: ErrorAlertMessage) {
         let alertController = UIAlertController(title: nil, message: error.errorDescription, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "확인", style: .default))
-        
-        present(alertController, animated: true)
+        if !(presentedViewController is UIAlertController) {
+            present(alertController, animated: true)
+        }
     }
-    
+        
 }
 
 private extension HomeViewController {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -420,11 +420,20 @@ private extension HomeViewController {
     
     func bindErrorAlert() {
         viewModel.errorAlertOutput
-            .bind { [weak self] message in
-                let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                alertController.addAction(UIAlertAction(title: "확인", style: .default))
-
-                self?.present(alertController, animated: true)
+            .bind { [weak self] error in
+                self?.presentErrorAlert(error: error)
+            }
+            .disposed(by: disposeBag)
+        
+        summaryInformationViewModel.errorAlertOutput
+            .bind { [weak self] error in
+                self?.presentErrorAlert(error: error)
+            }
+            .disposed(by: disposeBag)
+        
+        detailViewModel.errorAlertOutput
+            .bind { [weak self] error in
+                self?.presentErrorAlert(error: error)
             }
             .disposed(by: disposeBag)
     }
@@ -516,6 +525,13 @@ private extension HomeViewController {
                 latitude: northEastPoint.lat
             )
         )
+    }
+    
+    func presentErrorAlert(error: ErrorAlertMessage) {
+        let alertController = UIAlertController(title: nil, message: error.errorDescription, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "확인", style: .default))
+        
+        present(alertController, animated: true)
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -266,6 +266,7 @@ private extension HomeViewController {
         bindLocationButton()
         bindLocationAuthorization()
         bindStoreInformationView()
+        bindErrorAlert()
     }
     
     func bindRefresh() {
@@ -414,6 +415,17 @@ private extension HomeViewController {
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
+            .disposed(by: disposeBag)
+    }
+    
+    func bindErrorAlert() {
+        viewModel.errorAlertOutput
+            .bind { [weak self] message in
+                let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "확인", style: .default))
+
+                self?.present(alertController, animated: true)
+            }
             .disposed(by: disposeBag)
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -36,17 +36,21 @@ private extension DetailViewModelImpl {
     
     func setUIContents(store: Store) {
         fetchThumbnailImage(localPhotos: store.localPhotos)
-        setUIContentsOutput.accept(
-            DetailViewContents(
-                storeTitle: store.title,
-                category: store.category,
-                certificationTypes: store.certificationTypes,
-                address: store.address,
-                phoneNumber: store.phoneNumber ?? "전화번호 정보 없음",
-                openClosedContent: getOpenClosedUseCase.execute(openingHours: store.openingHour),
-                detailOpeningHour: detailOpeningHour(openingHours: store.openingHour)
+        do {
+            setUIContentsOutput.accept(
+                DetailViewContents(
+                    storeTitle: store.title,
+                    category: store.category,
+                    certificationTypes: store.certificationTypes,
+                    address: store.address,
+                    phoneNumber: store.phoneNumber ?? "전화번호 정보 없음",
+                    openClosedContent: try getOpenClosedUseCase.execute(openingHours: store.openingHour),
+                    detailOpeningHour: detailOpeningHour(openingHours: store.openingHour)
+                )
             )
-        )
+        } catch let error {
+            print(error.localizedDescription)
+        }
     }
     
     func fetchThumbnailImage(localPhotos: [String]) {

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -48,7 +48,7 @@ private extension DetailViewModelImpl {
                     detailOpeningHour: detailOpeningHour(openingHours: store.openingHour)
                 )
             )
-        } catch let error {
+        } catch {
             print(error.localizedDescription)
         }
     }

--- a/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/DetailViewModelImpl.swift
@@ -15,8 +15,9 @@ final class DetailViewModelImpl: DetailViewModel {
     let getOpenClosedUseCase: GetOpenClosedUseCase
     let fetchImageUseCase: FetchImageUseCase
     
-    var setUIContentsOutput = PublishRelay<DetailViewContents>()
-    var thumbnailImageOutput = PublishRelay<Data>()
+    let setUIContentsOutput = PublishRelay<DetailViewContents>()
+    let thumbnailImageOutput = PublishRelay<Data>()
+    let errorAlertOutput = PublishRelay<ErrorAlertMessage>()
     
     init(getOpenClosedUseCase: GetOpenClosedUseCase, fetchImageUseCase: FetchImageUseCase) {
         self.getOpenClosedUseCase = getOpenClosedUseCase
@@ -49,7 +50,7 @@ private extension DetailViewModelImpl {
                 )
             )
         } catch {
-            print(error.localizedDescription)
+            errorAlertOutput.accept(.data)
         }
     }
     
@@ -60,8 +61,8 @@ private extension DetailViewModelImpl {
                 onNext: { [weak self] imageData in
                     self?.thumbnailImageOutput.accept(imageData)
                 },
-                onError: { error in
-                    print(error.localizedDescription)
+                onError: { [weak self] _ in
+                    self?.errorAlertOutput.accept(.server)
                 }
             )
             .disposed(by: disposeBag)

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -16,17 +16,18 @@ final class HomeViewModelImpl: HomeViewModel {
     let fetchStoresUseCase: FetchStoresUseCase
     let getStoreInformationUseCase: GetStoreInformationUseCase
     
-    var getStoreInformationOutput = PublishRelay<Store>()
-    var refreshOutput = PublishRelay<[FilteredStores]>()
-    var locationButtonOutput = PublishRelay<NMFMyPositionMode>()
-    var locationButtonImageNameOutput = PublishRelay<String>()
-    var storeInformationViewHeightOutput = PublishRelay<StoreInformationViewConstraints>()
-    var summaryToDetailOutput = PublishRelay<Void>()
-    var detailToSummaryOutput = PublishRelay<Void>()
-    var setMarkerOutput = PublishRelay<MarkerContents>()
-    var locationAuthorizationStatusDeniedOutput = PublishRelay<Void>()
-    var locationStatusNotDeterminedOutput = PublishRelay<Void>()
-    var locationStatusAuthorizedWhenInUse = PublishRelay<Void>()
+    let getStoreInformationOutput = PublishRelay<Store>()
+    let refreshOutput = PublishRelay<[FilteredStores]>()
+    let locationButtonOutput = PublishRelay<NMFMyPositionMode>()
+    let locationButtonImageNameOutput = PublishRelay<String>()
+    let storeInformationViewHeightOutput = PublishRelay<StoreInformationViewConstraints>()
+    let summaryToDetailOutput = PublishRelay<Void>()
+    let detailToSummaryOutput = PublishRelay<Void>()
+    let setMarkerOutput = PublishRelay<MarkerContents>()
+    let locationAuthorizationStatusDeniedOutput = PublishRelay<Void>()
+    let locationStatusNotDeterminedOutput = PublishRelay<Void>()
+    let locationStatusAuthorizedWhenInUse = PublishRelay<Void>()
+    let errorAlertOutput = PublishRelay<String>()
     
     var dependency: HomeDependency
     
@@ -43,39 +44,39 @@ final class HomeViewModelImpl: HomeViewModel {
     }
     
     func action(input: HomeViewModelInputCase) {
-        do {
-            switch input {
-            case .refresh(let requestLocation):
-                refresh(requestLocation: requestLocation)
-            case .filterButtonTapped(let filter):
-                filterButtonTapped(filter: filter)
-            case .markerTapped(let tag):
-                try markerTapped(tag: tag)
-            case .locationButtonTapped(let locationAuthorizationStatus, let positionMode):
-                locationButtonTapped(locationAuthorizationStatus: locationAuthorizationStatus, positionMode: positionMode)
-            case .setStoreInformationOriginalHeight(let height):
-                setStoreInformationOriginalHeight(height: height)
-            case .storeInformationViewPanGestureChanged(let height):
-                storeInformationViewPanGestureChanged(height: height)
-            case .storeInformationViewPanGestureEnded(let height):
-                storeInformationViewPanGestureEnded(height: height)
-            case .storeInformationViewSwipe(let velocity):
-                storeInformationViewSwipe(velocity: velocity)
-            case .storeInformationViewTapGestureEnded:
-                storeInformationViewTapGestureEnded()
-            case .dimViewTapGestureEnded:
-                dimViewTapGestureEnded()
-            case .changeState(let state):
-                changeState(state: state)
-            case .setMarker(let store, let certificationType):
-                setMarker(store: store, certificationType: certificationType)
-            case .checkLocationAuthorization(let status):
-                checkLocationAuthorization(status: status)
-            case .checkLocationAuthorizationWhenCameraDidChange(let status):
-                checkLocationAuthorizationWhenCameraDidChange(status: status)
+        switch input {
+        case .refresh(let requestLocation):
+            refresh(requestLocation: requestLocation)
+        case .filterButtonTapped(let filter):
+            filterButtonTapped(filter: filter)
+        case .markerTapped(let tag):
+            do {
+                try markerTapped(tag: 10)
+            } catch {
+                errorAlertOutput.accept("알 수 없는 오류가 발생했습니다.")
             }
-        } catch {
-            print(error.localizedDescription)
+        case .locationButtonTapped(let locationAuthorizationStatus, let positionMode):
+            locationButtonTapped(locationAuthorizationStatus: locationAuthorizationStatus, positionMode: positionMode)
+        case .setStoreInformationOriginalHeight(let height):
+            setStoreInformationOriginalHeight(height: height)
+        case .storeInformationViewPanGestureChanged(let height):
+            storeInformationViewPanGestureChanged(height: height)
+        case .storeInformationViewPanGestureEnded(let height):
+            storeInformationViewPanGestureEnded(height: height)
+        case .storeInformationViewSwipe(let velocity):
+            storeInformationViewSwipe(velocity: velocity)
+        case .storeInformationViewTapGestureEnded:
+            storeInformationViewTapGestureEnded()
+        case .dimViewTapGestureEnded:
+            dimViewTapGestureEnded()
+        case .changeState(let state):
+            changeState(state: state)
+        case .setMarker(let store, let certificationType):
+            setMarker(store: store, certificationType: certificationType)
+        case .checkLocationAuthorization(let status):
+            checkLocationAuthorization(status: status)
+        case .checkLocationAuthorizationWhenCameraDidChange(let status):
+            checkLocationAuthorizationWhenCameraDidChange(status: status)
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/OpeningHourViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/OpeningHourViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  OpeningHourViewModel.swift
-//  KCS
-//
-//  Created by 김영현 on 1/25/24.
-//
-
-import Foundation

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
@@ -36,20 +36,25 @@ final class SummaryViewModelImpl: SummaryViewModel {
 private extension SummaryViewModelImpl {
     
     func setUIContents(store: Store) {
-        let openClosedContent = getOpenClosedUseCase.execute(openingHours: store.openingHour)
-        fetchThumbnailImage(localPhotos: store.localPhotos)
-        if let phoneNumber = store.phoneNumber {
-            callButtonOutput.accept(phoneNumber)
-        }
-        
-        setUIContentsOutput.accept(
-            SummaryViewContents(
-                storeTitle: store.title,
-                category: store.category,
-                certificationTypes: store.certificationTypes,
-                openClosedContent: openClosedContent
+        do {
+            let openClosedContent = try getOpenClosedUseCase.execute(openingHours: store.openingHour)
+            
+            fetchThumbnailImage(localPhotos: store.localPhotos)
+            if let phoneNumber = store.phoneNumber {
+                callButtonOutput.accept(phoneNumber)
+            }
+            
+            setUIContentsOutput.accept(
+                SummaryViewContents(
+                    storeTitle: store.title,
+                    category: store.category,
+                    certificationTypes: store.certificationTypes,
+                    openClosedContent: openClosedContent
+                )
             )
-        )
+        } catch let error {
+            print(error.localizedDescription)
+        }
     }
     
     func fetchThumbnailImage(localPhotos: [String]) {

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
@@ -52,7 +52,7 @@ private extension SummaryViewModelImpl {
                     openClosedContent: openClosedContent
                 )
             )
-        } catch let error {
+        } catch {
             print(error.localizedDescription)
         }
     }

--- a/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/SummaryViewModelImpl.swift
@@ -15,9 +15,10 @@ final class SummaryViewModelImpl: SummaryViewModel {
     let getOpenClosedUseCase: GetOpenClosedUseCase
     let fetchImageUseCase: FetchImageUseCase
     
-    var setUIContentsOutput = PublishRelay<SummaryViewContents>()
-    var thumbnailImageOutput = PublishRelay<Data>()
-    var callButtonOutput = PublishRelay<String>()
+    let setUIContentsOutput = PublishRelay<SummaryViewContents>()
+    let thumbnailImageOutput = PublishRelay<Data>()
+    let callButtonOutput = PublishRelay<String>()
+    let errorAlertOutput = PublishRelay<ErrorAlertMessage>()
     
     init(getOpenClosedUseCase: GetOpenClosedUseCase, fetchImageUseCase: FetchImageUseCase) {
         self.getOpenClosedUseCase = getOpenClosedUseCase
@@ -53,7 +54,7 @@ private extension SummaryViewModelImpl {
                 )
             )
         } catch {
-            print(error.localizedDescription)
+            errorAlertOutput.accept(.data)
         }
     }
     
@@ -64,8 +65,8 @@ private extension SummaryViewModelImpl {
                 onNext: { [weak self] imageData in
                     self?.thumbnailImageOutput.accept(imageData)
                 },
-                onError: { error in
-                    print(error.localizedDescription)
+                onError: { [weak self] _ in
+                    self?.errorAlertOutput.accept(.server)
                 }
             )
             .disposed(by: disposeBag)

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/DetailViewModel.swift
@@ -31,5 +31,6 @@ protocol DetailViewModelOutput {
     
     var setUIContentsOutput: PublishRelay<DetailViewContents> { get }
     var thumbnailImageOutput: PublishRelay<Data> { get }
+    var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -63,6 +63,6 @@ protocol HomeViewModelOutput {
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }
     var locationStatusAuthorizedWhenInUse: PublishRelay<Void> { get }
-    var errorAlertOutput: PublishRelay<String> { get }
+    var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -63,5 +63,6 @@ protocol HomeViewModelOutput {
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }
     var locationStatusAuthorizedWhenInUse: PublishRelay<Void> { get }
+    var errorAlertOutput: PublishRelay<String> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/SummaryViewModel.swift
@@ -34,5 +34,6 @@ protocol SummaryViewModelOutput {
     var setUIContentsOutput: PublishRelay<SummaryViewContents> { get }
     var thumbnailImageOutput: PublishRelay<Data> { get }
     var callButtonOutput: PublishRelay<String> { get }
+    var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #129

## 🚩 Summary

- 모든 에러를 Presentation Layer로 전달
- Error Alert 구현

| data | server |
| - | - |
| ![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/ee2a7ec1-1157-44f4-aae9-708bde386e40) | ![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/608c9fcd-edf6-47d7-a7b6-4287ce1f8d09) |

## 🛠️ Technical Concerns

### 사용자에게 보여줄 에러

사용자에게 상세한 에러를 전달하는 것은 사용자 경험에 좋지 못하다고 판단했다. 
예를 들면, Marker의 tag를 찾지 못하는 것을 사용자에게 알릴 필요는 없는 것이다.
그래서 사용자에게 보여줄 에러를 두가지로 결정했다. 

1. "데이터를 불러올 수 없습니다"
2. "서버와의 통신이 원활하지 않습니다"


### 모든 에러를 Presentation Layer로 전달

수 많은 곳에서 try, do-catch, throw, onError 등 에러와 관련된 문법을 사용했다. 
처리를 추후로 미루고 `print(error.localizedDescription)`로 디버깅 용도로만 사용했다.
이제 사용자에게 UIAlertController로 알리기 위해서 모든 레이어의 에러를 ViewController로 전달해야 했다.
그래서 onError, throws를 적극 활용하여 Presentation 영역인 ViewModel로 전달했다.
그 후, Output을 새로 만들어 ViewController에서 alert를 띄우는 것으로 처리했다.

### building | indexing paused 

빌드 과정에서 멈추고 빌드가 멈추는 현상이 발생했다. 
구글링을 통해서 다음과 같은 시도를 했다.

1. Derived Data 삭제
2. Xcode 재시작
3. Xcode 업데이트
4. xcworkspace 재생성

하지만 해결하지 못했고, 원인을 코드에서 발견했다.
lazy var로 생성하는 변수에 try를 넣었던 부분에서 발생한 오류였으며, lazy가 필요하지 않은 부분이었기 때문에 lazy를 삭제하여 해결했다. 

## 📋 To Do

- FilterButton Tap -> RefreshButton 사라지는 현상 발견
