### PR TITLE
필터 버튼과 검색 로직 분리

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -262,6 +262,7 @@ private extension HomeViewController {
     
     func bind() {
         bindRefresh()
+        bindApplyFilters()
         bindSetMarker()
         bindLocationButton()
         bindLocationAuthorization()
@@ -271,6 +272,15 @@ private extension HomeViewController {
     
     func bindRefresh() {
         viewModel.refreshOutput
+            .bind { [weak self] _ in
+                self?.refreshButton.animationInvalidate()
+                self?.storeInformationViewDismiss()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    func bindApplyFilters() {
+        viewModel.applyFiltersOutput
             .bind { [weak self] filteredStores in
                 guard let self = self else { return }
                 self.markers.forEach { $0.mapView = nil }
@@ -284,8 +294,6 @@ private extension HomeViewController {
                         )
                     }
                 }
-                refreshButton.animationInvalidate()
-                storeInformationViewDismiss()
             }
             .disposed(by: disposeBag)
     }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -17,7 +17,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let getStoreInformationUseCase: GetStoreInformationUseCase
     
     let getStoreInformationOutput = PublishRelay<Store>()
-    let refreshOutput = PublishRelay<[FilteredStores]>()
+    let refreshOutput = PublishRelay<Void>()
     let locationButtonOutput = PublishRelay<NMFMyPositionMode>()
     let locationButtonImageNameOutput = PublishRelay<String>()
     let storeInformationViewHeightOutput = PublishRelay<StoreInformationViewConstraints>()
@@ -28,6 +28,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let locationStatusNotDeterminedOutput = PublishRelay<Void>()
     let locationStatusAuthorizedWhenInUse = PublishRelay<Void>()
     let errorAlertOutput = PublishRelay<ErrorAlertMessage>()
+    let applyFiltersOutput = PublishRelay<[FilteredStores]>()
     
     var dependency: HomeDependency
     
@@ -90,6 +91,7 @@ private extension HomeViewModelImpl {
             onNext: { [weak self] stores in
                 guard let self = self else { return }
                 applyFilters(stores: stores, filters: getActivatedTypes())
+                refreshOutput.accept(())
             },
             onError: { [weak self] error in
                 if error is StoreRepositoryError {
@@ -151,7 +153,7 @@ private extension HomeViewModelImpl {
                 }
             }
         }
-        refreshOutput.accept([goodPriceStores, exemplaryStores, safeStores])
+        applyFiltersOutput.accept([goodPriceStores, exemplaryStores, safeStores])
     }
     
     func markerTapped(tag: UInt) {

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -53,7 +53,8 @@ protocol HomeViewModelInput {
 protocol HomeViewModelOutput {
     
     var getStoreInformationOutput: PublishRelay<Store> { get }
-    var refreshOutput: PublishRelay<[FilteredStores]> { get }
+    var refreshOutput: PublishRelay<Void> { get }
+    var applyFiltersOutput: PublishRelay<[FilteredStores]> { get }
     var locationButtonOutput: PublishRelay<NMFMyPositionMode> { get }
     var locationButtonImageNameOutput: PublishRelay<String> { get }
     var storeInformationViewHeightOutput: PublishRelay<StoreInformationViewConstraints> { get }


### PR DESCRIPTION
## ⭐️ Issue Number

- #132

## 🚩 Summary

- 검색과 필터의 로직 분리
- 필터 버튼을 눌렀을 때, 검색 버튼이 사라지는 현상 제거

## 🛠️ Technical Concerns

### 겹치는 로직과 분리되는 로직

그래서 필터 버튼을 누르면 검색 버튼이 눌린 것 처럼 검색 버튼이 사라지는 현상이 있었다.
필터 버튼을 누르는 것과 검색 버튼을 누르는 것은 똑같은 로직이 사용되기 때문에 Output을 하나로 사용하여 이러한 현상이 발생했다.
검색은 새로운 데이터를 받아와 활성화된 필터를 적용시키는 것이고 필터 버튼은 필터를 변경하고 활성화된 필터를 적용시키는 것이다.
활성화된 필터를 적용시키는 것이 겹친다. 그렇기 때문에 겹치는 Output을 분리하고 영향이 없는 다른 부분은 따로 Output을 둬서 처리하여 해결했다.  

