### PR TITLE
DetailView constraint 및 font size 수정

### DIFF
--- a/KCS/KCS/Presentation/Home/View/CertificationLabel.swift
+++ b/KCS/KCS/Presentation/Home/View/CertificationLabel.swift
@@ -11,21 +11,18 @@ final class CertificationLabel: UIView {
     
     private let certificationType: CertificationType
     
-    private let fontSize: CGFloat
-    
     private lazy var certificationLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.pretendard(size: fontSize, weight: .medium)
+        label.font = UIFont.pretendard(size: 9, weight: .medium)
         label.textColor = UIColor.grayLabel
         label.text = certificationType.description
         
         return label
     }()
 
-    init(certificationType: CertificationType, fontSize: CGFloat) {
+    init(certificationType: CertificationType) {
         self.certificationType = certificationType
-        self.fontSize = fontSize
         super.init(frame: .zero)
         
         setBackgroundColor()

--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -16,7 +16,7 @@ final class DetailView: UIView {
     private lazy var storeTitle: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.pretendard(size: 24, weight: .bold)
+        label.font = UIFont.pretendard(size: 22, weight: .bold)
         label.textColor = UIColor.primary2
         label.numberOfLines = 2
         
@@ -175,7 +175,7 @@ private extension DetailView {
                 category.text = detailViewContents.category
                 detailViewContents.certificationTypes
                     .map({
-                        CertificationLabel(certificationType: $0, fontSize: 11)
+                        CertificationLabel(certificationType: $0)
                     })
                     .forEach { [weak self] in
                         self?.certificationStackView.addArrangedSubview($0)
@@ -241,16 +241,17 @@ private extension DetailView {
     func storeRepresentConstraints() {
         NSLayoutConstraint.activate([
             storeTitle.topAnchor.constraint(equalTo: topAnchor, constant: 27),
-            storeTitle.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
+            storeTitle.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            storeTitle.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
         ])
         
         NSLayoutConstraint.activate([
-            category.topAnchor.constraint(equalTo: storeTitle.bottomAnchor, constant: 8),
+            category.topAnchor.constraint(equalTo: storeTitle.bottomAnchor, constant: 4),
             category.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            certificationStackView.topAnchor.constraint(equalTo: category.bottomAnchor, constant: 11),
+            certificationStackView.topAnchor.constraint(equalTo: category.bottomAnchor, constant: 9),
             certificationStackView.leadingAnchor.constraint(equalTo: storeTitle.leadingAnchor)
         ])
         

--- a/KCS/KCS/Presentation/Home/View/Marker.swift
+++ b/KCS/KCS/Presentation/Home/View/Marker.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class Marker: NMFMarker {
     
-    private lazy var unselectedGlobalZIndex: Int = self.globalZIndex
+    private var unselectedGlobalZIndex: Int?
     private let selectImage: NMFOverlayImage
     private let deselectImage: NMFOverlayImage
 
@@ -19,6 +19,7 @@ final class Marker: NMFMarker {
         self.selectImage = NMFOverlayImage(image: selectImage)
         self.deselectImage = NMFOverlayImage(image: deselectImage)
         super.init()
+        self.unselectedGlobalZIndex = globalZIndex
         if let position = position {
             self.position = position
         }
@@ -36,7 +37,8 @@ extension Marker {
     
     func deselect() {
         self.iconImage = deselectImage
-        self.globalZIndex = unselectedGlobalZIndex
+        guard let zIndex = unselectedGlobalZIndex else { return }
+        self.globalZIndex = zIndex
     }
 
 }

--- a/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryInformationView.swift
@@ -131,7 +131,7 @@ private extension SummaryInformationView {
                 category.text = contents.category
                 contents.certificationTypes
                     .map({
-                        CertificationLabel(certificationType: $0, fontSize: 9)
+                        CertificationLabel(certificationType: $0)
                     })
                     .forEach { [weak self] in
                         self?.certificationStackView.addArrangedSubview($0)


### PR DESCRIPTION
## ⭐️ Issue Number

- #133 

## 🚩 Summary

- DetailView의 store title constraint 설정

|![Simulator Screenshot - iPhone 15 - 2024-01-31 at 03 45 40](https://github.com/Korea-Certified-Store/iOS/assets/62226667/9db2eedb-1f71-4391-936a-8035d96df310)|![Simulator Screenshot - iPhone 15 - 2024-01-31 at 03 45 32](https://github.com/Korea-Certified-Store/iOS/assets/62226667/b65b3b0c-8153-482a-aa92-39553f5c674a)|
|--|--|
|Summary View|Detail View|

- 업데이트된 figma에 맞도록 DetailView의 font size 및 constraints 수정
- 겹치는 마커 선택 후 해제 시 다시 원래있던 제자리로 돌아가도록 수정

https://github.com/Korea-Certified-Store/iOS/assets/62226667/01971468-5c58-4714-9696-4d2c03984507

