### PR TITLE
SummaryView 이미지 scaleAspectFill으로 수정

### DIFF
--- a/KCS/KCS/Presentation/Home/View/DetailView.swift
+++ b/KCS/KCS/Presentation/Home/View/DetailView.swift
@@ -56,6 +56,7 @@ final class DetailView: UIView {
         imageView.setLayerCorner(cornerRadius: 6)
         imageView.clipsToBounds = true
         imageView.image = UIImage.basicStore
+        imageView.contentMode = .scaleAspectFill
         
         return imageView
     }()

--- a/KCS/KCS/Presentation/Home/View/SummaryView.swift
+++ b/KCS/KCS/Presentation/Home/View/SummaryView.swift
@@ -66,6 +66,7 @@ final class SummaryView: UIView {
         imageView.setLayerCorner(cornerRadius: 6)
         imageView.clipsToBounds = true
         imageView.image = UIImage.basicStore
+        imageView.contentMode = .scaleAspectFill
         
         return imageView
     }()

--- a/KCS/KCS/Presentation/StoreList/View/StoreTableViewCell.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreTableViewCell.swift
@@ -45,6 +45,7 @@ final class StoreTableViewCell: UITableViewCell {
         imageView.setLayerCorner(cornerRadius: 4)
         imageView.clipsToBounds = true
         imageView.image = UIImage.basicStore
+        imageView.contentMode = .scaleAspectFill
         
         return imageView
     }()


### PR DESCRIPTION
## ⭐️ Issue Number

- #146

## 🚩 Summary

- SummaryView 이미지 scaleAspectFill으로 수정

## 🛠️ Technical Concerns

### ScaleAspectFill

|<img src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/3a121bb1-17ec-4410-a8d4-23835c4265e4" width=200 height=200>|<img src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/51860ea1-4fbe-487a-a661-24a050f783c2" width=200 height=200>|
|-|-|

ScaleAspectFill의 경우 사진처럼 위 아래가 잘리는 현상이 있다. 
하지만 UX를 고려했을 때 아래와 같이 사진이 너무 왜곡되는 현상을 제거하기 위해서 ScaleAspectFill로 변경했다.

|![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/f01120b1-eb46-46ef-b894-fd944edeaa00)|
| - |

