### PR TITLE
StoreListViewController 상단 Title 추가

### DIFF
--- a/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
+++ b/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
@@ -8,9 +8,12 @@
 import UIKit
 
 extension UISheetPresentationController.Detent.Identifier {
+    
     static let smallSummaryDetentIdentifier = UISheetPresentationController.Detent.Identifier("SmallSummaryDetent")
     static let largeSummaryDetentIdentifier = UISheetPresentationController.Detent.Identifier("LargeSummaryDetent")
     static let detailDetentIdentifier = UISheetPresentationController.Detent.Identifier("DetailDetent")
+    static let smallStoreListViewDetentIdentifier = UISheetPresentationController.Detent.Identifier("SmallListDetent")
+    static let largeStoreListViewDetentIdentifier = UISheetPresentationController.Detent.Identifier("LargeListDetent")
 }
             
 extension UISheetPresentationController.Detent {
@@ -23,6 +26,10 @@ extension UISheetPresentationController.Detent {
     }
     static let detailViewDetent = custom(identifier: .detailDetentIdentifier) { _ in
         return 616 - 21
+    }    
+    static let smallStoreListViewDetent = custom(identifier: .smallStoreListViewDetentIdentifier) { _ in
+        return 35
     }
+    static let largeStoreListViewDetent = large()
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -528,15 +528,12 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     }
     
     func presentStoreListView() {
-        let listNavigationController = UINavigationController(rootViewController: storeListViewController)
-        listNavigationController.navigationBar.backgroundColor = .white
-        listNavigationController.navigationBar.isTranslucent = false
-        if let sheet = listNavigationController.sheetPresentationController {
+        if let sheet = storeListViewController.sheetPresentationController {
             sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
             sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
             sheet.prefersGrabberVisible = true
         }
-        present(listNavigationController, animated: true)
+        present(storeListViewController, animated: true)
     }
     
 }
@@ -545,6 +542,7 @@ extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         storeInformationViewDismiss()
+        presentStoreListView()
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -528,15 +528,15 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     }
     
     func presentStoreListView() {
-        let newNC = UINavigationController(rootViewController: storeListViewController)
-        newNC.navigationBar.backgroundColor = .white
-        newNC.navigationBar.isTranslucent = false
-        if let sheet = newNC.sheetPresentationController {
+        let listNavigationController = UINavigationController(rootViewController: storeListViewController)
+        listNavigationController.navigationBar.backgroundColor = .white
+        listNavigationController.navigationBar.isTranslucent = false
+        if let sheet = listNavigationController.sheetPresentationController {
             sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
             sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
             sheet.prefersGrabberVisible = true
         }
-        present(newNC, animated: true)
+        present(listNavigationController, animated: true)
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -532,6 +532,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
             sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
             sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 15
         }
         present(storeListViewController, animated: true)
     }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -545,7 +545,6 @@ extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         storeInformationViewDismiss()
-        presentStoreListView()
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -186,18 +186,21 @@ final class HomeViewController: UIViewController {
         addUIComponents()
         configureConstraints()
         bind()
+        setup()
+    }
+    
+}
+
+private extension HomeViewController {
+    
+    func setup() {        
         unDimmedView()
-        
         viewModel.action(
             input: .checkLocationAuthorization(
                 status: locationManager.authorizationStatus
             )
         )
     }
-    
-}
-
-private extension HomeViewController {
     
     func bind() {
         bindRefresh()
@@ -524,12 +527,25 @@ extension HomeViewController: NMFMapViewCameraDelegate {
         }
     }
     
+    func presentStoreListView() {
+        let newNC = UINavigationController(rootViewController: storeListViewController)
+        newNC.navigationBar.backgroundColor = .white
+        newNC.navigationBar.isTranslucent = false
+        if let sheet = newNC.sheetPresentationController {
+            sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
+            sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
+            sheet.prefersGrabberVisible = true
+        }
+        present(newNC, animated: true)
+    }
+    
 }
 
 extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         storeInformationViewDismiss()
+        presentStoreListView()
     }
     
 }

--- a/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
@@ -41,16 +41,15 @@ final class StoreInformationViewController: UIViewController {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         
-        isModalInPresentation = true
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setBackgroundColor()
         addUIComponents()
         configureConstraints()
         bind()
+        setup()
     }
     
     required init?(coder: NSCoder) {
@@ -60,6 +59,11 @@ final class StoreInformationViewController: UIViewController {
 }
 
 extension StoreInformationViewController {
+    
+    func setup() {
+        view.backgroundColor = .white
+        isModalInPresentation = true
+    }
     
     func bind() {
         viewModel.errorAlertOutput
@@ -122,9 +126,6 @@ extension StoreInformationViewController {
 
 private extension StoreInformationViewController {
     
-    func setBackgroundColor() {
-        view.backgroundColor = .white
-    }
     
     func addUIComponents() {
         view.addSubview(summaryView)

--- a/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
@@ -12,6 +12,17 @@ final class StoreListViewController: UIViewController {
     
     private let disposeBag = DisposeBag()
     
+    private let titleBar: UINavigationBar = {
+        let navigationBar = UINavigationBar()
+        navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        let titleItem = UINavigationItem(title: "가게 모아보기")
+        navigationBar.setItems([titleItem], animated: true)
+        navigationBar.backgroundColor = .white
+        navigationBar.isTranslucent = false
+        
+        return navigationBar
+    }()
+    
     private let storeTableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -72,17 +83,23 @@ final class StoreListViewController: UIViewController {
 private extension StoreListViewController {
     
     func setup() {
-        title = "가게 모아보기"
         isModalInPresentation = true
     }
     
     func addUIComponents() {
         view.addSubview(storeTableView)
+        view.addSubview(titleBar)
     }
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            storeTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            titleBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            titleBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            titleBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            storeTableView.topAnchor.constraint(equalTo: titleBar.bottomAnchor),
             storeTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             storeTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             storeTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)

--- a/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
@@ -60,6 +60,7 @@ final class StoreListViewController: UIViewController {
         addUIComponents()
         configureConstraints()
         bind()
+        setup()
     }
     
     func updateList(stores: [Store]) {
@@ -69,6 +70,11 @@ final class StoreListViewController: UIViewController {
 }
 
 private extension StoreListViewController {
+    
+    func setup() {
+        title = "가게 모아보기"
+        isModalInPresentation = true
+    }
     
     func addUIComponents() {
         view.addSubview(storeTableView)


### PR DESCRIPTION
## ⭐️ Issue Number

- #152

## 🚩 Summary

- 네비게이션 타이틀 추가
- detent 추가

|![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/b566180f-07bf-47b1-aaa9-2725b4bbaeb3)|![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/8cb3c6d8-be9b-4177-991a-bae0e8e0bb90)|
|-|-|


## 🛠️ Technical Concerns

### title을 정하는 방법

현재 UINavigationController가 없기 때문에 상단에 title을 정해줄 수 있는 방법이 없었다.
그래서 present하기 전 UINavigationController를 설정해줘서 해결했다.
현재 StoreListViewController와 StoreInformationViewController 모두 present 방식으로 사용하고 있다.
하나의 UIViewController에서 2개의 UIViewController를 present하는 것은 불가능하기 때문에 추후에 수정이 필요하다.

## 📋 To Do

- present 방식 수정
