### PR TITLE
StoreListViewController present, dismiss 플로우 적용

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -189,6 +189,12 @@ final class HomeViewController: UIViewController {
         setup()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        presentStoreListView()
+    }
+    
 }
 
 private extension HomeViewController {
@@ -307,6 +313,7 @@ private extension HomeViewController {
             }
             storeInformationViewController.changeToSummary()
             if !(presentedViewController is StoreInformationViewController) {
+                dismiss(animated: true)
                 present(storeInformationViewController, animated: true)
             }
         }
@@ -393,6 +400,7 @@ private extension HomeViewController {
         clickedMarker = nil
         if !changeMarker {
             storeInformationViewController.dismiss(animated: true)
+            presentStoreListView()
         }
     }
     
@@ -528,13 +536,15 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     }
     
     func presentStoreListView() {
-        if let sheet = storeListViewController.sheetPresentationController {
-            sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
-            sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
-            sheet.prefersGrabberVisible = true
-            sheet.preferredCornerRadius = 15
+        if !(presentedViewController is StoreListViewController) {
+            if let sheet = storeListViewController.sheetPresentationController {
+                sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
+                sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
+                sheet.prefersGrabberVisible = true
+                sheet.preferredCornerRadius = 15
+            }
+            present(storeListViewController, animated: true)
         }
-        present(storeListViewController, animated: true)
     }
     
 }
@@ -543,7 +553,6 @@ extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         storeInformationViewDismiss()
-        presentStoreListView()
     }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #154

## 🚩 Summary

- StoreListViewController와 StoreInformationViewController dismiss, present 플로우

![Simulator Screen Recording - iPhone 15 Pro - 2024-02-04 at 15 39 56](https://github.com/Korea-Certified-Store/iOS/assets/128480641/1d3b129a-f3a7-4357-8a89-9721446579d7)


## 🛠️ Technical Concerns

### present 중첩 불가 해결

하나의 UIViewController에서 두개의 UIViewController를 present하는 것은 불가능하다.
StoreListViewController와 StoreInformationViewController 모두 UISheetPresentationController를 사용해야 했기 때문에 present를 사용해야 했다. 
그래서 하나의 UIViewController가 올라올 타이밍에 다른 하나를 dismiss 하는 방식으로 해결했다.

## 📋 To Do

- StoreListViewController에서 Cell 선택시 Marker 및 SummaryView로 이동
- RefreshButton, LocationButton Constraints
