### PR TITLE
가게 리스트 더보기 기능 구현

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		A81EFBC72B5D597400D0C0D7 /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A81EFBBE2B5D597400D0C0D7 /* Pretendard-Bold.ttf */; };
 		A81EFBC82B5D597400D0C0D7 /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */; };
 		A81EFBCA2B5D5A2300D0C0D7 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */; };
+		A83367B62B6F993F00E0A844 /* MoreStoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83367B52B6F993F00E0A844 /* MoreStoreButton.swift */; };
 		A89087042B4E7F3500767225 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087032B4E7F3500767225 /* FilterButton.swift */; };
 		A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087092B4EF00B00767225 /* SystemImage.swift */; };
 		A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870C2B4EF91600767225 /* UIView+SetLayer.swift */; };
@@ -202,6 +203,7 @@
 		A81EFBBE2B5D597400D0C0D7 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		A83367B52B6F993F00E0A844 /* MoreStoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreStoreButton.swift; sourceTree = "<group>"; };
 		A89087032B4E7F3500767225 /* FilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterButton.swift; sourceTree = "<group>"; };
 		A89087092B4EF00B00767225 /* SystemImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImage.swift; sourceTree = "<group>"; };
 		A890870C2B4EF91600767225 /* UIView+SetLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SetLayer.swift"; sourceTree = "<group>"; };
@@ -402,6 +404,7 @@
 				59C306A32B4D7EBA00862625 /* Marker.swift */,
 				A89087032B4E7F3500767225 /* FilterButton.swift */,
 				5977BE572B5524D500725C90 /* RefreshButton.swift */,
+				A83367B52B6F993F00E0A844 /* MoreStoreButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -934,6 +937,7 @@
 				5977BE742B57FA7A00725C90 /* FilteredStores.swift in Sources */,
 				A8A7E05D2B64AF1300D015E5 /* StoreInformationViewConstraints.swift in Sources */,
 				5977BE5E2B5535C700725C90 /* FetchRefreshStoresUseCase.swift in Sources */,
+				A83367B62B6F993F00E0A844 /* MoreStoreButton.swift in Sources */,
 				59C306B02B4FFE4400862625 /* StoreResponse.swift in Sources */,
 				A8A7E0602B64E62200D015E5 /* NMFMyPosition+.swift in Sources */,
 				A8ACB7EA2B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		A81EFBC82B5D597400D0C0D7 /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */; };
 		A81EFBCA2B5D5A2300D0C0D7 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */; };
 		A83367B62B6F993F00E0A844 /* MoreStoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83367B52B6F993F00E0A844 /* MoreStoreButton.swift */; };
+		A83367B82B6FA0E700E0A844 /* FetchStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83367B72B6FA0E700E0A844 /* FetchStores.swift */; };
 		A89087042B4E7F3500767225 /* FilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087032B4E7F3500767225 /* FilterButton.swift */; };
 		A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087092B4EF00B00767225 /* SystemImage.swift */; };
 		A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870C2B4EF91600767225 /* UIView+SetLayer.swift */; };
@@ -204,6 +205,7 @@
 		A81EFBBF2B5D597400D0C0D7 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		A83367B52B6F993F00E0A844 /* MoreStoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreStoreButton.swift; sourceTree = "<group>"; };
+		A83367B72B6FA0E700E0A844 /* FetchStores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStores.swift; sourceTree = "<group>"; };
 		A89087032B4E7F3500767225 /* FilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterButton.swift; sourceTree = "<group>"; };
 		A89087092B4EF00B00767225 /* SystemImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImage.swift; sourceTree = "<group>"; };
 		A890870C2B4EF91600767225 /* UIView+SetLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SetLayer.swift"; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */,
 				59B8864F2B6AB9F7005750EF /* StoreTableViewCellContents.swift */,
 				59B886632B6EC816005750EF /* SummaryViewHeightCase.swift */,
+				A83367B72B6FA0E700E0A844 /* FetchStores.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -927,6 +930,7 @@
 				A89087042B4E7F3500767225 /* FilterButton.swift in Sources */,
 				59F478B12B59BB00002FEF9E /* ImageRepositoryError.swift in Sources */,
 				59C306C92B501B9D00862625 /* RegularOpeningHours.swift in Sources */,
+				A83367B82B6FA0E700E0A844 /* FetchStores.swift in Sources */,
 				59F478B52B59BE0B002FEF9E /* FetchImageUseCase.swift in Sources */,
 				59C306BF2B50109100862625 /* Location.swift in Sources */,
 				A8A7E05B2B642EC900D015E5 /* DetailViewContents.swift in Sources */,

--- a/KCS/KCS/Data/Network/Response/Protocol/APIResponse.swift
+++ b/KCS/KCS/Data/Network/Response/Protocol/APIResponse.swift
@@ -13,6 +13,6 @@ protocol APIResponse: Codable {
     
     var code: Int { get }
     var message: String { get }
-    var data: [ResponseType] { get }
+    var data: [[ResponseType]] { get }
     
 }

--- a/KCS/KCS/Data/Network/Response/StoreResponse.swift
+++ b/KCS/KCS/Data/Network/Response/StoreResponse.swift
@@ -13,6 +13,6 @@ struct StoreResponse: APIResponse {
     
     let code: Int
     let message: String
-    let data: [ResponseType]
+    let data: [[ResponseType]]
     
 }

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -20,7 +20,7 @@ extension StoreAPI: Router, URLRequestConvertible {
     var baseURL: String? {
         switch self {
         case .getStores:
-            return getURL(type: .product)
+            return getURL(type: .develop)
         case .getImage(let url):
             return url
         }

--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -44,7 +44,12 @@ final class StoreRepositoryImpl: StoreRepository {
                                 )
                             )
                         } else {
-                            observer.onError(JSONContentsError.bundleRead)
+                            observer.onNext(
+                                FetchStores(
+                                    fetchCountContent: FetchCountContent(),
+                                    stores: []
+                                )
+                            )
                         }
                     case .failure(let error):
                         throw error

--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -18,8 +18,8 @@ final class StoreRepositoryImpl: StoreRepository {
     
     func fetchRefreshStores(
         requestLocation: RequestLocation
-    ) -> Observable<[Store]> {
-        return Observable<[Store]>.create { observer -> Disposable in
+    ) -> Observable<FetchStores> {
+        return Observable<FetchStores>.create { observer -> Disposable in
             AF.request(StoreAPI.getStores(location: RequestLocationDTO(
                 nwLong: requestLocation.northWest.longitude,
                 nwLat: requestLocation.northWest.latitude,
@@ -37,7 +37,12 @@ final class StoreRepositoryImpl: StoreRepository {
                         let resultStores = try result.data.map { try $0.map { try $0.toEntity() } }
                         self?.stores = resultStores
                         if let firstIndexStore = resultStores.first {
-                            observer.onNext(firstIndexStore)
+                            observer.onNext(
+                                FetchStores(
+                                    fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count),
+                                    stores: firstIndexStore
+                                )
+                            )
                         } else {
                             observer.onError(JSONContentsError.bundleRead)
                         }
@@ -54,7 +59,7 @@ final class StoreRepositoryImpl: StoreRepository {
     
     func fetchStores(count: Int) -> [Store] {
         var fetchResult: [Store] = []
-        for index in 0..<count + 1 {
+        for index in 0..<count {
             fetchResult.append(contentsOf: stores[index])
         }
         return fetchResult

--- a/KCS/KCS/Domain/Entity/FetchStores.swift
+++ b/KCS/KCS/Domain/Entity/FetchStores.swift
@@ -1,0 +1,22 @@
+//
+//  FetchStores.swift
+//  KCS
+//
+//  Created by 김영현 on 2/4/24.
+//
+
+import Foundation
+
+struct FetchStores {
+    
+    let fetchCountContent: FetchCountContent
+    let stores: [Store]
+    
+}
+
+struct FetchCountContent {
+    
+    var maxFetchCount: Int = 1
+    var fetchCount: Int = 1
+    
+}

--- a/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
@@ -11,7 +11,7 @@ protocol StoreRepository {
     
     func fetchRefreshStores(
         requestLocation: RequestLocation
-    ) -> Observable<[Store]>
+    ) -> Observable<FetchStores>
     
     func fetchStores(count: Int) -> [Store]
     

--- a/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
+++ b/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
@@ -15,6 +15,6 @@ protocol FetchRefreshStoresUseCase {
     
     func execute(
         requestLocation: RequestLocation
-    ) -> Observable<[Store]>
+    ) -> Observable<FetchStores>
 
 }

--- a/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
@@ -14,8 +14,8 @@ struct FetchRefreshStoresUseCaseImpl: FetchRefreshStoresUseCase {
     func execute(
         requestLocation: RequestLocation
     ) -> Observable<[Store]> {
-        let newLocation = parallelTranslate(requestLocation: requestLocation)
-        return repository.fetchRefreshStores(requestLocation: newLocation)
+//        let newLocation = parallelTranslate(requestLocation: requestLocation)
+        return repository.fetchRefreshStores(requestLocation: requestLocation)
     }
     
 }

--- a/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
@@ -13,84 +13,8 @@ struct FetchRefreshStoresUseCaseImpl: FetchRefreshStoresUseCase {
     
     func execute(
         requestLocation: RequestLocation
-    ) -> Observable<[Store]> {
-//        let newLocation = parallelTranslate(requestLocation: requestLocation)
+    ) -> Observable<FetchStores> {
         return repository.fetchRefreshStores(requestLocation: requestLocation)
-    }
-    
-}
-
-private extension FetchRefreshStoresUseCaseImpl {
-    
-    func parallelTranslate (requestLocation: RequestLocation) -> RequestLocation {
-        let distance1 = sqrt(
-            pow(requestLocation.northWest.longitude - requestLocation.southWest.longitude, 2)
-            + pow(requestLocation.northWest.latitude - requestLocation.southWest.latitude, 2)
-        )
-        let distance2 = sqrt(
-            pow(requestLocation.northWest.longitude - requestLocation.northEast.longitude, 2) +
-            pow(requestLocation.northWest.latitude - requestLocation.northEast.latitude, 2)
-        )
-        
-        let center = Location(
-            longitude: (requestLocation.northWest.longitude + requestLocation.southEast.longitude) / 2.0,
-            latitude: (requestLocation.northWest.latitude + requestLocation.southEast.latitude) / 2.0
-        )
-        
-        var newLocation: RequestLocation
-        if distance1 > 0.07 {
-            newLocation = translateHeightLocations(
-                loc1: requestLocation.northWest,
-                loc2: requestLocation.northEast,
-                center: center
-            )
-            if distance2 > 0.07 {
-                newLocation = translateHeightLocations(
-                    loc1: newLocation.northEast,
-                    loc2: newLocation.southEast,
-                    center: center
-                )
-            }
-            return newLocation
-        }
-        
-        return requestLocation
-    }
-    
-    func translateHeightLocations(loc1: Location, loc2: Location, center: Location) -> RequestLocation {
-        if loc1.latitude == loc2.latitude {
-            return RequestLocation(
-                northWest: Location(longitude: loc1.longitude, latitude: center.latitude + 0.035),
-                southWest: Location(longitude: loc1.longitude, latitude: center.latitude - 0.035),
-                southEast: Location(longitude: loc2.longitude, latitude: center.latitude - 0.035),
-                northEast: Location(longitude: loc2.longitude, latitude: center.latitude + 0.035)
-            )
-        } else if loc1.longitude == loc2.longitude {
-            return RequestLocation(
-                northWest: Location(longitude: center.longitude + 0.035, latitude: loc1.latitude),
-                southWest: Location(longitude: center.longitude - 0.035, latitude: loc1.latitude),
-                southEast: Location(longitude: center.longitude - 0.035, latitude: loc2.latitude),
-                northEast: Location(longitude: center.longitude + 0.035, latitude: loc2.latitude)
-            )
-        }
-        
-        let slope = (loc2.latitude - loc1.latitude) / (loc2.longitude - loc1.longitude)
-        let constant1 = 0.035 * sqrt(pow(slope, 2) + 1) - slope * center.longitude + center.latitude
-        let constant2 = (-0.035) * sqrt(pow(slope, 2) + 1) - slope * center.longitude + center.latitude
-        
-        return RequestLocation(
-            northWest: getNewLocation(location: loc1, slope: slope, constant: constant1),
-            southWest: getNewLocation(location: loc1, slope: slope, constant: constant2),
-            southEast: getNewLocation(location: loc2, slope: slope, constant: constant2),
-            northEast: getNewLocation(location: loc2, slope: slope, constant: constant1)
-        )
-    }
-    
-    func getNewLocation(location: Location, slope: Double, constant: Double) -> Location {
-        return Location(
-            longitude: (location.latitude + (location.longitude / slope) - constant) / (slope + 1 / slope),
-            latitude: (slope * location.latitude + location.longitude + constant / slope) / (slope + 1 / slope)
-        )
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -131,7 +131,20 @@ final class HomeViewController: UIViewController {
                     )
                 )
             }
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
+        
+        return button
+    }()
+    
+    private lazy var moreStoreButton: MoreStoreButton = {
+        let button = MoreStoreButton()
+        button.isHidden = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.rx.tap
+            .bind { [weak self] in
+                self?.viewModel.action(input: .moreStoreButtonTapped)
+            }
+            .disposed(by: disposeBag)
         
         return button
     }()
@@ -222,6 +235,8 @@ private extension HomeViewController {
         viewModel.refreshDoneOutput
             .bind { [weak self] _ in
                 self?.refreshButton.animationInvalidate()
+                self?.refreshButton.isHidden = true
+                self?.moreStoreButton.isHidden = false
             }
             .disposed(by: disposeBag)
     }
@@ -458,6 +473,7 @@ private extension HomeViewController {
         mapView.addSubview(locationButton)
         mapView.addSubview(filterButtonStackView)
         mapView.addSubview(refreshButton)
+        mapView.addSubview(moreStoreButton)
         mapView.addSubview(dimView)
     }
     
@@ -493,6 +509,11 @@ private extension HomeViewController {
             refreshButton.heightAnchor.constraint(equalToConstant: 35),
             refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
         ])
+        
+        NSLayoutConstraint.activate([
+            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
+            moreStoreButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
+        ])
     }
     
 }
@@ -516,6 +537,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             locationButton.setImage(UIImage.locationButtonNone, for: .normal)
         }
         refreshButton.isHidden = false
+        moreStoreButton.isHidden = true
     }
     
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -239,7 +239,7 @@ private extension HomeViewController {
                 self?.refreshButton.animationInvalidate()
                 self?.refreshButton.isHidden = true
                 self?.moreStoreButton.isHidden = false
-                self?.moreStoreButton.isUserInteractionEnabled = true
+                self?.moreStoreButton.isEnabled = true
             }
             .disposed(by: disposeBag)
         
@@ -251,7 +251,7 @@ private extension HomeViewController {
         
         viewModel.noMoreStoresOutput
             .bind { [weak self] in
-                self?.moreStoreButton.isUserInteractionEnabled = false
+                self?.moreStoreButton.isEnabled = false
             }
             .disposed(by: disposeBag)
     }
@@ -521,12 +521,14 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
             refreshButton.widthAnchor.constraint(equalToConstant: 110),
-            refreshButton.heightAnchor.constraint(equalToConstant: 35)
+            refreshButton.heightAnchor.constraint(equalToConstant: 35),
+            refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
             // TODO: bottom constraints 필요
         ])
         
         NSLayoutConstraint.activate([
-            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor)
+            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
+            moreStoreButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
             // TODO: bottom constraints 필요
         ])
     }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -219,7 +219,7 @@ private extension HomeViewController {
     }
     
     func bindRefresh() {
-        viewModel.refreshOutput
+        viewModel.refreshDoneOutput
             .bind { [weak self] _ in
                 self?.refreshButton.animationInvalidate()
             }
@@ -227,7 +227,7 @@ private extension HomeViewController {
     }
     
     func bindApplyFilters() {
-        viewModel.applyFiltersOutput
+        viewModel.filteredStoresOutput
             .bind { [weak self] filteredStores in
                 guard let self = self else { return }
                 self.markers.forEach { $0.mapView = nil }
@@ -355,7 +355,7 @@ private extension HomeViewController {
             .scan(false) { [weak self] (lastState, _) in
                 guard let self = self else { return lastState }
                 viewModel.action(
-                    input: .filterButtonTapped(activatedFilter: type, fetchCount: 1)
+                    input: .filterButtonTapped(activatedFilter: type)
                     // TODO: fetchCount Dependency에서 처리
                 )
                 return !lastState
@@ -490,7 +490,8 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
             refreshButton.widthAnchor.constraint(equalToConstant: 110),
-            refreshButton.heightAnchor.constraint(equalToConstant: 35)
+            refreshButton.heightAnchor.constraint(equalToConstant: 35),
+            refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
         ])
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -138,11 +138,13 @@ final class HomeViewController: UIViewController {
     
     private lazy var moreStoreButton: MoreStoreButton = {
         let button = MoreStoreButton()
-        button.isHidden = true
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
         button.rx.tap
             .bind { [weak self] in
-                self?.viewModel.action(input: .moreStoreButtonTapped)
+                self?.viewModel.action(
+                    input: .moreStoreButtonTapped
+                )
             }
             .disposed(by: disposeBag)
         
@@ -233,10 +235,23 @@ private extension HomeViewController {
     
     func bindRefresh() {
         viewModel.refreshDoneOutput
-            .bind { [weak self] _ in
+            .bind { [weak self] in
                 self?.refreshButton.animationInvalidate()
                 self?.refreshButton.isHidden = true
                 self?.moreStoreButton.isHidden = false
+                self?.moreStoreButton.isUserInteractionEnabled = true
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.fetchCountOutput
+            .bind { [weak self] fetchCount in
+                self?.moreStoreButton.setFetchCount(fetchCount: fetchCount)
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.noMoreStoresOutput
+            .bind { [weak self] in
+                self?.moreStoreButton.isUserInteractionEnabled = false
             }
             .disposed(by: disposeBag)
     }
@@ -371,7 +386,6 @@ private extension HomeViewController {
                 guard let self = self else { return lastState }
                 viewModel.action(
                     input: .filterButtonTapped(activatedFilter: type)
-                    // TODO: fetchCount Dependency에서 처리
                 )
                 return !lastState
             }
@@ -496,6 +510,7 @@ private extension HomeViewController {
             locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             locationButton.widthAnchor.constraint(equalToConstant: 48),
             locationButton.heightAnchor.constraint(equalToConstant: 48)
+            // TODO: bottom constraints 필요
         ])
         
         NSLayoutConstraint.activate([
@@ -506,13 +521,13 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
             refreshButton.widthAnchor.constraint(equalToConstant: 110),
-            refreshButton.heightAnchor.constraint(equalToConstant: 35),
-            refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
+            refreshButton.heightAnchor.constraint(equalToConstant: 35)
+            // TODO: bottom constraints 필요
         ])
         
         NSLayoutConstraint.activate([
-            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
-            moreStoreButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
+            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor)
+            // TODO: bottom constraints 필요
         ])
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -224,7 +224,7 @@ private extension HomeViewController {
     }
     
     func bind() {
-        bindRefresh()
+        bindFetchStores()
         bindApplyFilters()
         bindSetMarker()
         bindLocationButton()
@@ -233,7 +233,7 @@ private extension HomeViewController {
         bindErrorAlert()
     }
     
-    func bindRefresh() {
+    func bindFetchStores() {
         viewModel.refreshDoneOutput
             .bind { [weak self] in
                 self?.refreshButton.animationInvalidate()

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -21,6 +21,7 @@ final class MoreStoreButton: UIButton {
     
     init() {
         super.init(frame: .zero)
+        setUI()
         setLayerShadow(shadowOffset: CGSize(width: 0, height: 2))
     }
     
@@ -31,9 +32,15 @@ final class MoreStoreButton: UIButton {
     func setFetchCount(fetchCount: FetchCountContent) {
         var titleAttribute = AttributedString(String(format: "결과 더보기 %d/%d", fetchCount.fetchCount, fetchCount.maxFetchCount))
         titleAttribute.font = UIFont.pretendard(size: 10, weight: .medium)
-        
+        configuration?.attributedTitle = titleAttribute
+    }
+    
+}
+
+private extension MoreStoreButton {
+    
+    func setUI() {
         var config = UIButton.Configuration.filled()
-        config.attributedTitle = titleAttribute
         config.baseBackgroundColor = .white
         config.baseForegroundColor = .black
         config.cornerStyle = .capsule

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -1,0 +1,44 @@
+//
+//  MoreStoreButton.swift
+//  KCS
+//
+//  Created by 김영현 on 2/4/24.
+//
+
+import UIKit
+
+final class MoreStoreButton: UIButton {
+    
+    private let originalTitle: AttributedString = {
+        var titleAttribute = AttributedString("결과 더보기")
+        titleAttribute.font = UIFont.pretendard(size: 10, weight: .medium)
+        
+        return titleAttribute
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        setUI()
+        setLayerShadow(shadowOffset: CGSize(width: 0, height: 2))
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension MoreStoreButton {
+    
+    func setUI() {
+        var config = UIButton.Configuration.filled()
+        config.attributedTitle = originalTitle
+        config.baseBackgroundColor = .white
+        config.baseForegroundColor = .black
+        config.cornerStyle = .capsule
+        config.contentInsets = NSDirectionalEdgeInsets(top: 11, leading: 10, bottom: 11, trailing: 10)
+        configuration = config
+    }
+    
+}
+

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -9,9 +9,9 @@ import UIKit
 
 final class MoreStoreButton: UIButton {
     
-    override var isUserInteractionEnabled: Bool {
+    override var isEnabled: Bool {
         didSet {
-            if isUserInteractionEnabled {
+            if isEnabled {
                 configuration?.baseForegroundColor = .black
             } else {
                 configuration?.baseForegroundColor = .grayLabel
@@ -41,7 +41,7 @@ private extension MoreStoreButton {
     
     func setUI() {
         var config = UIButton.Configuration.filled()
-        config.baseBackgroundColor = .white
+        config.background.backgroundColor = .white
         config.baseForegroundColor = .black
         config.cornerStyle = .capsule
         config.contentInsets = NSDirectionalEdgeInsets(top: 11, leading: 10, bottom: 11, trailing: 10)

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -9,16 +9,18 @@ import UIKit
 
 final class MoreStoreButton: UIButton {
     
-    private let originalTitle: AttributedString = {
-        var titleAttribute = AttributedString("결과 더보기")
-        titleAttribute.font = UIFont.pretendard(size: 10, weight: .medium)
-        
-        return titleAttribute
-    }()
+    override var isUserInteractionEnabled: Bool {
+        didSet {
+            if isUserInteractionEnabled {
+                configuration?.baseForegroundColor = .black
+            } else {
+                configuration?.baseForegroundColor = .grayLabel
+            }
+        }
+    }
     
     init() {
         super.init(frame: .zero)
-        setUI()
         setLayerShadow(shadowOffset: CGSize(width: 0, height: 2))
     }
     
@@ -26,13 +28,12 @@ final class MoreStoreButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-}
-
-private extension MoreStoreButton {
-    
-    func setUI() {
+    func setFetchCount(fetchCount: FetchCountContent) {
+        var titleAttribute = AttributedString(String(format: "결과 더보기 %d/%d", fetchCount.fetchCount, fetchCount.maxFetchCount))
+        titleAttribute.font = UIFont.pretendard(size: 10, weight: .medium)
+        
         var config = UIButton.Configuration.filled()
-        config.attributedTitle = originalTitle
+        config.attributedTitle = titleAttribute
         config.baseBackgroundColor = .white
         config.baseForegroundColor = .black
         config.cornerStyle = .capsule
@@ -41,4 +42,3 @@ private extension MoreStoreButton {
     }
     
 }
-

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeDependency.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeDependency.swift
@@ -11,6 +11,11 @@ struct HomeDependency {
     
     let disposeBag = DisposeBag()
     var activatedFilter: [CertificationType] = []
-    var fetchCount: Int = .zero
+    var fetchCount: Int = 1
+    var maxFetchCount: Int = 1
+    
+    mutating func resetFetchCount() {
+        fetchCount = 1
+    }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeDependency.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeDependency.swift
@@ -11,5 +11,6 @@ struct HomeDependency {
     
     let disposeBag = DisposeBag()
     var activatedFilter: [CertificationType] = []
+    var fetchCount: Int = .zero
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -85,6 +85,7 @@ private extension HomeViewModelImpl {
                 applyFilters(stores: refreshContent.stores, filters: getActivatedTypes())
                 fetchCountOutput.accept(FetchCountContent(maxFetchCount: dependency.maxFetchCount))
                 refreshDoneOutput.accept(())
+                checkLastFetch()
             },
             onError: { [weak self] error in
                 if error is StoreRepositoryError {
@@ -103,7 +104,10 @@ private extension HomeViewModelImpl {
             applyFilters(stores: fetchStoresUseCase.execute(fetchCount: dependency.fetchCount), filters: getActivatedTypes())
             fetchCountOutput.accept(FetchCountContent(maxFetchCount: dependency.maxFetchCount, fetchCount: dependency.fetchCount))
         }
-        
+        checkLastFetch()
+    }
+    
+    func checkLastFetch() {
         if dependency.fetchCount == dependency.maxFetchCount {
             noMoreStoresOutput.accept(())
         }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -46,6 +46,8 @@ final class HomeViewModelImpl: HomeViewModel {
         switch input {
         case .refresh(let requestLocation):
             refresh(requestLocation: requestLocation)
+        case .moreStoreButtonTapped:
+            moreStoreButtonTapped()
         case .filterButtonTapped(let filter):
             filterButtonTapped(filter: filter)
         case .markerTapped(let tag):
@@ -76,6 +78,7 @@ private extension HomeViewModelImpl {
         .subscribe(
             onNext: { [weak self] stores in
                 guard let self = self else { return }
+                dependency.fetchCount = .zero
                 applyFilters(stores: stores, filters: getActivatedTypes())
                 refreshDoneOutput.accept(())
             },
@@ -88,6 +91,11 @@ private extension HomeViewModelImpl {
             }
         )
         .disposed(by: dependency.disposeBag)
+    }
+    
+    func moreStoreButtonTapped() {
+        dependency.fetchCount += 1
+        applyFilters(stores: fetchStoresUseCase.execute(fetchCount: dependency.fetchCount), filters: getActivatedTypes())
     }
     
     func filterButtonTapped(filter: CertificationType) {

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -28,7 +28,7 @@ protocol HomeViewModel: HomeViewModelInput, HomeViewModelOutput {
 enum HomeViewModelInputCase {
     
     case refresh(requestLocation: RequestLocation)
-    case filterButtonTapped(activatedFilter: CertificationType, fetchCount: Int)
+    case filterButtonTapped(activatedFilter: CertificationType)
     case markerTapped(tag: UInt)
     case locationButtonTapped(locationAuthorizationStatus: CLAuthorizationStatus, positionMode: NMFMyPositionMode)
     case dimViewTapGestureEnded
@@ -47,8 +47,8 @@ protocol HomeViewModelInput {
 protocol HomeViewModelOutput {
     
     var getStoreInformationOutput: PublishRelay<Store> { get }
-    var refreshOutput: PublishRelay<Void> { get }
-    var applyFiltersOutput: PublishRelay<[FilteredStores]> { get }
+    var refreshDoneOutput: PublishRelay<Void> { get }
+    var filteredStoresOutput: PublishRelay<[FilteredStores]> { get }
     var locationButtonOutput: PublishRelay<NMFMyPositionMode> { get }
     var locationButtonImageNameOutput: PublishRelay<String> { get }
     var setMarkerOutput: PublishRelay<MarkerContents> { get }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -57,6 +57,8 @@ protocol HomeViewModelOutput {
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }
     var locationStatusAuthorizedWhenInUse: PublishRelay<Void> { get }
     var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
+    var fetchCountOutput: PublishRelay<FetchCountContent> { get }
+    var noMoreStoresOutput: PublishRelay<Void> { get }
     var dimViewTapGestureEndedOutput: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -28,6 +28,7 @@ protocol HomeViewModel: HomeViewModelInput, HomeViewModelOutput {
 enum HomeViewModelInputCase {
     
     case refresh(requestLocation: RequestLocation)
+    case moreStoreButtonTapped
     case filterButtonTapped(activatedFilter: CertificationType)
     case markerTapped(tag: UInt)
     case locationButtonTapped(locationAuthorizationStatus: CLAuthorizationStatus, positionMode: NMFMyPositionMode)

--- a/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
@@ -126,7 +126,6 @@ extension StoreInformationViewController {
 
 private extension StoreInformationViewController {
     
-    
     func addUIComponents() {
         view.addSubview(summaryView)
         view.addSubview(detailView)


### PR DESCRIPTION
## ⭐️ Issue Number

- #156 

## 🚩 Summary

- 바뀐 API를 적용하여 더보기 버튼을 누를 때마다 리스트에 가게가 추가되는 기능 추가
- 가게 더보기 버튼 생성

## 🛠️ Technical Concerns

### Fetch Count의 사용

가게 더보기 버튼을 사용하기 위해서는 현재 몇 번째 리스트까지 불러왔는지와 최대 몇 번 까지 더보기 버튼을 누를 수 있는지에 대한 값을 알아야 했다.
이를 `FetchCount`라는 Entity를 만들어 데이터를 넘겨주는 방식으로 로직을 구성하였다.
```swift
struct FetchCountContent {
    
    var maxFetchCount: Int = 1
    var fetchCount: Int = 1
    
}
```

### MoreStoreButton `isEnabled` vs `isUserInteractionEnabled`

가게 더보기 버튼은 누를 수 있는 최대 횟수를 채우면 버튼이 눌리지 않도록 설정해야한다. 이를 `isEnabled`를 사용하여 해결하려 해봤지만 디자인과 다르게 `isEnabled`를 하는 경우 버튼이 opacity되는 이슈가 발생하였다.
`didSet`을 사용하여 따로 configuration을 변경해 보았지만 적용되지 않아서 `isUserInteractionEnabled`를 사용하여 figma와 동일한 디자인으로 버튼을 만들어줄 수 있었다.
```swift
final class MoreStoreButton: UIButton {

    override var isUserInteractionEnabled: Bool {
        didSet {
            if isUserInteractionEnabled {
                configuration?.baseForegroundColor = .black
            } else {
                configuration?.baseForegroundColor = .grayLabel
            }
        }
    }
    ...
}
```

## 📋 To Do

- LocationButton과 RefreshButton, MoreStoreButton 3개의 bottom constraints를 설정해주어야 합니다.
- 첫 화면에서는 예외적으로 API에서 받아온 모든 마커들과 그에 해당하는 가게 리스트들을 모두 띄워주어야 합니다.
- present error alert의 수정이 필요합니다.
