### PR TITLE
Error Alert present 오류 해결

### DIFF
--- a/KCS/KCS/Presentation/Extension/UIViewController+ErrorAlert.swift
+++ b/KCS/KCS/Presentation/Extension/UIViewController+ErrorAlert.swift
@@ -12,9 +12,12 @@ extension UIViewController {
     func presentErrorAlert(error: ErrorAlertMessage) {
         let alertController = UIAlertController(title: nil, message: error.errorDescription, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "확인", style: .default))
-        if !(presentedViewController is UIAlertController) {
+        if let presentController = presentedViewController {
+            presentController.presentErrorAlert(error: error)
+        } else {
             present(alertController, animated: true)
         }
+        
     }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #161

## 🚩 Summary

- UIViewController extension 수정

## 🛠️ Technical Concerns

### present 중첩 해결

Error Alert는 항상 present로 보여주고 있었다. 
HomeViewController는 항상 StoreInformationViewController와 StoreListViewController 둘 중 하나를 present 하고 있기 때문에 중첩으로 present 할 수 업다는 오류가 발생했다.
그래서 Error Alert를 present하는 경우에만 재귀를 이용하여 보여주고있는 최상단의 presentedViewController를 찾아서 present하는 방식으로 해결했다.
```swift
extension UIViewController {
    
    func presentErrorAlert(error: ErrorAlertMessage) {
        let alertController = UIAlertController(title: nil, message: error.errorDescription, preferredStyle: .alert)
        alertController.addAction(UIAlertAction(title: "확인", style: .default))
        if let presentController = presentedViewController {
            presentController.presentErrorAlert(error: error)
        } else {
            present(alertController, animated: true)
        }
        
    }
    
}

```
