### PR TITLE
앱 실행 후 첫 화면일 경우 모든 마커 띄우기

### DIFF
--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -18,7 +18,7 @@ final class StoreRepositoryImpl: StoreRepository {
     
     func fetchRefreshStores(
         requestLocation: RequestLocation,
-        isFirst: Bool
+        isEntire: Bool
     ) -> Observable<FetchStores> {
         return Observable<FetchStores>.create { observer -> Disposable in
             AF.request(StoreAPI.getStores(location: RequestLocationDTO(
@@ -38,7 +38,7 @@ final class StoreRepositoryImpl: StoreRepository {
                         let resultStores = try result.data.map { try $0.map { try $0.toEntity() } }
                         var fetchStores: FetchStores
                         self?.stores = resultStores
-                        if isFirst {
+                        if isEntire {
                             fetchStores = FetchStores(
                                 fetchCountContent: FetchCountContent(),
                                 stores: resultStores.flatMap { $0 }

--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -17,7 +17,8 @@ final class StoreRepositoryImpl: StoreRepository {
     }
     
     func fetchRefreshStores(
-        requestLocation: RequestLocation
+        requestLocation: RequestLocation,
+        isFirst: Bool
     ) -> Observable<FetchStores> {
         return Observable<FetchStores>.create { observer -> Disposable in
             AF.request(StoreAPI.getStores(location: RequestLocationDTO(
@@ -35,22 +36,27 @@ final class StoreRepositoryImpl: StoreRepository {
                     switch response.result {
                     case .success(let result):
                         let resultStores = try result.data.map { try $0.map { try $0.toEntity() } }
+                        var fetchStores: FetchStores
                         self?.stores = resultStores
-                        if let firstIndexStore = resultStores.first {
-                            observer.onNext(
-                                FetchStores(
+                        if isFirst {
+                            fetchStores = FetchStores(
+                                fetchCountContent: FetchCountContent(),
+                                stores: resultStores.flatMap { $0 }
+                            )
+                        } else {
+                            if let firstIndexStore = resultStores.first {
+                                fetchStores = FetchStores(
                                     fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count),
                                     stores: firstIndexStore
                                 )
-                            )
-                        } else {
-                            observer.onNext(
-                                FetchStores(
+                            } else {
+                                fetchStores = FetchStores(
                                     fetchCountContent: FetchCountContent(),
                                     stores: []
                                 )
-                            )
+                            }
                         }
+                        observer.onNext(fetchStores)
                     case .failure(let error):
                         throw error
                     }

--- a/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
@@ -10,7 +10,8 @@ import RxSwift
 protocol StoreRepository {
     
     func fetchRefreshStores(
-        requestLocation: RequestLocation
+        requestLocation: RequestLocation,
+        isFirst: Bool
     ) -> Observable<FetchStores>
     
     func fetchStores(count: Int) -> [Store]

--- a/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/StoreRepository.swift
@@ -11,7 +11,7 @@ protocol StoreRepository {
     
     func fetchRefreshStores(
         requestLocation: RequestLocation,
-        isFirst: Bool
+        isEntire: Bool
     ) -> Observable<FetchStores>
     
     func fetchStores(count: Int) -> [Store]

--- a/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
+++ b/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
@@ -15,7 +15,7 @@ protocol FetchRefreshStoresUseCase {
     
     func execute(
         requestLocation: RequestLocation,
-        isFirst: Bool
+        isEntire: Bool
     ) -> Observable<FetchStores>
 
 }

--- a/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
+++ b/KCS/KCS/Domain/Interface/UseCase/FetchRefreshStoresUseCase.swift
@@ -14,7 +14,8 @@ protocol FetchRefreshStoresUseCase {
     init(repository: StoreRepository)
     
     func execute(
-        requestLocation: RequestLocation
+        requestLocation: RequestLocation,
+        isFirst: Bool
     ) -> Observable<FetchStores>
 
 }

--- a/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
@@ -13,9 +13,9 @@ struct FetchRefreshStoresUseCaseImpl: FetchRefreshStoresUseCase {
     
     func execute(
         requestLocation: RequestLocation,
-        isFirst: Bool
+        isEntire: Bool
     ) -> Observable<FetchStores> {
-        return repository.fetchRefreshStores(requestLocation: requestLocation, isFirst: isFirst)
+        return repository.fetchRefreshStores(requestLocation: requestLocation, isEntire: isEntire)
     }
     
 }

--- a/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/FetchRefreshStoresUseCaseImpl.swift
@@ -12,9 +12,10 @@ struct FetchRefreshStoresUseCaseImpl: FetchRefreshStoresUseCase {
     let repository: StoreRepository
     
     func execute(
-        requestLocation: RequestLocation
+        requestLocation: RequestLocation,
+        isFirst: Bool
     ) -> Observable<FetchStores> {
-        return repository.fetchRefreshStores(requestLocation: requestLocation)
+        return repository.fetchRefreshStores(requestLocation: requestLocation, isFirst: isFirst)
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -243,10 +243,10 @@ private extension HomeViewController {
     
     func bindFetchStores() {
         viewModel.refreshDoneOutput
-            .bind { [weak self] in
+            .bind { [weak self] isFirst in
                 self?.refreshButton.animationInvalidate()
                 self?.refreshButton.isHidden = true
-                self?.moreStoreButton.isHidden = false
+                self?.moreStoreButton.isHidden = isFirst
                 self?.moreStoreButton.isEnabled = true
             }
             .disposed(by: disposeBag)
@@ -535,12 +535,14 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
             refreshButton.widthAnchor.constraint(equalToConstant: 110),
-            refreshButton.heightAnchor.constraint(equalToConstant: 35)
+            refreshButton.heightAnchor.constraint(equalToConstant: 35),
+            refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
             // TODO: bottom constraints 필요
         ])
         
         NSLayoutConstraint.activate([
-            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor)
+            moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
+            moreStoreButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
             // TODO: bottom constraints 필요
         ])
     }
@@ -581,7 +583,8 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             refreshButton.animationFire()
             viewModel.action(
                 input: .refresh(
-                    requestLocation: makeRequestLocation(projection: mapView.projection)
+                    requestLocation: makeRequestLocation(projection: mapView.projection),
+                    isFirst: true
                 )
             )
         }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -243,10 +243,10 @@ private extension HomeViewController {
     
     func bindFetchStores() {
         viewModel.refreshDoneOutput
-            .bind { [weak self] isFirst in
+            .bind { [weak self] isEntire in
                 self?.refreshButton.animationInvalidate()
                 self?.refreshButton.isHidden = true
-                self?.moreStoreButton.isHidden = isFirst
+                self?.moreStoreButton.isHidden = isEntire
                 self?.moreStoreButton.isEnabled = true
             }
             .disposed(by: disposeBag)
@@ -584,7 +584,7 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             viewModel.action(
                 input: .refresh(
                     requestLocation: makeRequestLocation(projection: mapView.projection),
-                    isFirst: true
+                    isEntire: true
                 )
             )
         }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -46,8 +46,8 @@ final class HomeViewModelImpl: HomeViewModel {
     
     func action(input: HomeViewModelInputCase) {
         switch input {
-        case .refresh(let requestLocation, let isFirst):
-            refresh(requestLocation: requestLocation, isFirst: isFirst)
+        case .refresh(let requestLocation, let isEntire):
+            refresh(requestLocation: requestLocation, isEntire: isEntire)
         case .moreStoreButtonTapped:
             moreStoreButtonTapped()
         case .filterButtonTapped(let filter):
@@ -73,11 +73,11 @@ private extension HomeViewModelImpl {
     
     func refresh(
         requestLocation: RequestLocation,
-        isFirst: Bool
+        isEntire: Bool
     ) {
         fetchRefreshStoresUseCase.execute(
             requestLocation: requestLocation,
-            isFirst: isFirst
+            isEntire: isEntire
         )
         .subscribe(
             onNext: { [weak self] refreshContent in
@@ -86,7 +86,7 @@ private extension HomeViewModelImpl {
                 dependency.maxFetchCount = refreshContent.fetchCountContent.maxFetchCount
                 applyFilters(stores: refreshContent.stores, filters: getActivatedTypes())
                 fetchCountOutput.accept(FetchCountContent(maxFetchCount: dependency.maxFetchCount))
-                refreshDoneOutput.accept(isFirst)
+                refreshDoneOutput.accept(isEntire)
                 checkLastFetch()
             },
             onError: { [weak self] error in

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -17,7 +17,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let getStoreInformationUseCase: GetStoreInformationUseCase
     
     let getStoreInformationOutput = PublishRelay<Store>()
-    let refreshDoneOutput = PublishRelay<Void>()
+    let refreshDoneOutput = PublishRelay<Bool>()
     let locationButtonOutput = PublishRelay<NMFMyPositionMode>()
     let locationButtonImageNameOutput = PublishRelay<String>()
     let setMarkerOutput = PublishRelay<MarkerContents>()
@@ -46,8 +46,8 @@ final class HomeViewModelImpl: HomeViewModel {
     
     func action(input: HomeViewModelInputCase) {
         switch input {
-        case .refresh(let requestLocation):
-            refresh(requestLocation: requestLocation)
+        case .refresh(let requestLocation, let isFirst):
+            refresh(requestLocation: requestLocation, isFirst: isFirst)
         case .moreStoreButtonTapped:
             moreStoreButtonTapped()
         case .filterButtonTapped(let filter):
@@ -72,10 +72,12 @@ final class HomeViewModelImpl: HomeViewModel {
 private extension HomeViewModelImpl {
     
     func refresh(
-        requestLocation: RequestLocation
+        requestLocation: RequestLocation,
+        isFirst: Bool
     ) {
         fetchRefreshStoresUseCase.execute(
-            requestLocation: requestLocation
+            requestLocation: requestLocation,
+            isFirst: isFirst
         )
         .subscribe(
             onNext: { [weak self] refreshContent in
@@ -84,7 +86,7 @@ private extension HomeViewModelImpl {
                 dependency.maxFetchCount = refreshContent.fetchCountContent.maxFetchCount
                 applyFilters(stores: refreshContent.stores, filters: getActivatedTypes())
                 fetchCountOutput.accept(FetchCountContent(maxFetchCount: dependency.maxFetchCount))
-                refreshDoneOutput.accept(())
+                refreshDoneOutput.accept(isFirst)
                 checkLastFetch()
             },
             onError: { [weak self] error in

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -27,7 +27,7 @@ protocol HomeViewModel: HomeViewModelInput, HomeViewModelOutput {
 
 enum HomeViewModelInputCase {
     
-    case refresh(requestLocation: RequestLocation)
+    case refresh(requestLocation: RequestLocation, isFirst: Bool = false)
     case moreStoreButtonTapped
     case filterButtonTapped(activatedFilter: CertificationType)
     case markerTapped(tag: UInt)
@@ -48,7 +48,7 @@ protocol HomeViewModelInput {
 protocol HomeViewModelOutput {
     
     var getStoreInformationOutput: PublishRelay<Store> { get }
-    var refreshDoneOutput: PublishRelay<Void> { get }
+    var refreshDoneOutput: PublishRelay<Bool> { get }
     var filteredStoresOutput: PublishRelay<[FilteredStores]> { get }
     var locationButtonOutput: PublishRelay<NMFMyPositionMode> { get }
     var locationButtonImageNameOutput: PublishRelay<String> { get }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -27,7 +27,7 @@ protocol HomeViewModel: HomeViewModelInput, HomeViewModelOutput {
 
 enum HomeViewModelInputCase {
     
-    case refresh(requestLocation: RequestLocation, isFirst: Bool = false)
+    case refresh(requestLocation: RequestLocation, isEntire: Bool = false)
     case moreStoreButtonTapped
     case filterButtonTapped(activatedFilter: CertificationType)
     case markerTapped(tag: UInt)


### PR DESCRIPTION
## ⭐️ Issue Number

- #165 

## 🚩 Summary

- 앱 실행 후 첫 화면에서는 지도에 나타나는 모든 마커와 가게 리스트를 띄워준다.

|![Simulator Screen Recording - iPhone 15 - 2024-02-05 at 13 15 51](https://github.com/Korea-Certified-Store/iOS/assets/62226667/b2ed9a5b-29c6-4b12-9e00-4ccaa3049496)|![Simulator Screen Recording - iPhone 15 - 2024-02-05 at 13 17 18](https://github.com/Korea-Certified-Store/iOS/assets/62226667/6cf03743-8249-497a-99fc-7da3e3036e90)|
|:--:|:--:|
|첫 실행 시|나머지 로직|

## 🙇🏻‍♀️ To Reviewer
- 테스트를 위한 임의의 Constraints값은 빼지 않았습니다. 추후에 하단 button들의 constraints들을 수정할 때 같이 수정하도록 하겠습니다.