### PR TITLE
direct mode에서 재검색 버튼 클릭시 position mode normal로 변경

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -255,6 +255,8 @@ private extension HomeViewController {
                 self?.refreshButton.isHidden = true
                 self?.moreStoreButton.isHidden = isEntire
                 self?.moreStoreButton.isEnabled = true
+                self?.mapView.mapView.positionMode = .normal
+                self?.locationButton.setImage(UIImage.locationButtonNone, for: .normal)
             }
             .disposed(by: disposeBag)
         
@@ -560,7 +562,8 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             locationButton.widthAnchor.constraint(equalToConstant: 48),
-            locationButton.heightAnchor.constraint(equalToConstant: 48)
+            locationButton.heightAnchor.constraint(equalToConstant: 48),
+            locationButton.bottomAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.bottomAnchor, constant: -100)
             // TODO: bottom constraints 필요
         ])
         

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -562,8 +562,7 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             locationButton.widthAnchor.constraint(equalToConstant: 48),
-            locationButton.heightAnchor.constraint(equalToConstant: 48),
-            locationButton.bottomAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.bottomAnchor, constant: -100)
+            locationButton.heightAnchor.constraint(equalToConstant: 48)
             // TODO: bottom constraints 필요
         ])
         


### PR DESCRIPTION
## ⭐️ Issue Number

- #172 

## 🚩 Summary

- 위치 재검색을 하는 경우 mapView의 position mode를 normal 모드로 변경한다.

![Simulator Screen Recording - iPhone 15 - 2024-02-07 at 04 10 28](https://github.com/Korea-Certified-Store/iOS/assets/62226667/87f51746-cd43-4b59-ab4f-d7c00a31b47d)
