### PR TITLE
현위치 버튼 및 재검색 버튼 위치 로직 조정

### DIFF
--- a/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
+++ b/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
@@ -28,7 +28,7 @@ extension UISheetPresentationController.Detent {
         return 616 - 21
     }    
     static let smallStoreListViewDetent = custom(identifier: .smallStoreListViewDetentIdentifier) { _ in
-        return 35
+        return 40
     }
     static let largeStoreListViewDetent = large()
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -93,8 +93,8 @@ final class HomeViewController: UIViewController {
         map.showScaleBar = false
         map.showIndoorLevelPicker = false
         map.showLocationButton = false
-        map.mapView.logoAlign = .rightTop
-        map.mapView.logoMargin = UIEdgeInsets(top: 28, left: 0, bottom: 0, right: 0)
+        map.mapView.logoAlign = .rightBottom
+        map.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: 55, right: 0)
         map.mapView.touchDelegate = self
         map.mapView.addCameraDelegate(delegate: self)
         
@@ -606,10 +606,12 @@ private extension HomeViewController {
             refreshButtonBottomConstraint.constant = -260
             locationButtonBottomConstraint.constant = -260
             moreStoreButtonBottomConstraint.constant = -260
+            mapView.mapView.logoMargin.bottom = 225
         } else {
             refreshButtonBottomConstraint.constant = -283
             locationButtonBottomConstraint.constant = -283
             moreStoreButtonBottomConstraint.constant = -283
+            mapView.mapView.logoMargin.bottom = 248
         }
         UIView.animate(withDuration: 0.3, delay: delay ? 0.5 : 0) {
             self.view.layoutIfNeeded()
@@ -661,6 +663,10 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             refreshButtonBottomConstraint.constant = -90
             locationButtonBottomConstraint.constant = -90
             moreStoreButtonBottomConstraint.constant = -90
+            mapView.mapView.logoMargin.bottom = 55
+            UIView.animate(withDuration: 0.5) {
+                self.view.layoutIfNeeded()
+            }
             present(storeListViewController, animated: true)
         }
     }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -178,6 +178,18 @@ final class HomeViewController: UIViewController {
         return view
     }()
     
+    private lazy var refreshButtonBottomConstraint = refreshButton.bottomAnchor.constraint(
+        equalTo: mapView.bottomAnchor, constant: -90
+    )
+    
+    private lazy var moreStoreButtonBottomConstraint = moreStoreButton.bottomAnchor.constraint(
+        equalTo: mapView.bottomAnchor, constant: -90
+    )
+    
+    private lazy var locationButtonBottomConstraint = locationButton.bottomAnchor.constraint(
+        equalTo: mapView.bottomAnchor, constant: -90
+    )
+    
     private let disposeBag = DisposeBag()
     private var markers: [Marker] = []
     private let storeInformationViewController: StoreInformationViewController
@@ -327,6 +339,7 @@ private extension HomeViewController {
         viewModel.getStoreInformationOutput
             .bind { [weak self] store in
                 self?.storeInformationViewController.setUIContents(store: store)
+                self?.changeButtonsConstraints(delay: false)
             }
             .disposed(by: disposeBag)
         
@@ -358,6 +371,7 @@ private extension HomeViewController {
             storeInformationViewController.changeToSummary()
             if !(presentedViewController is StoreInformationViewController) {
                 dismiss(animated: true)
+                changeButtonsConstraints(delay: true)
                 present(storeInformationViewController, animated: true)
             }
         }
@@ -558,8 +572,8 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             locationButton.widthAnchor.constraint(equalToConstant: 48),
-            locationButton.heightAnchor.constraint(equalToConstant: 48)
-            // TODO: bottom constraints 필요
+            locationButton.heightAnchor.constraint(equalToConstant: 48),
+            locationButtonBottomConstraint
         ])
         
         NSLayoutConstraint.activate([
@@ -576,15 +590,30 @@ private extension HomeViewController {
             refreshButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
             refreshButton.widthAnchor.constraint(equalToConstant: 110),
             refreshButton.heightAnchor.constraint(equalToConstant: 35),
-            refreshButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
-            // TODO: bottom constraints 필요
+            refreshButtonBottomConstraint
         ])
         
         NSLayoutConstraint.activate([
             moreStoreButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor),
-            moreStoreButton.bottomAnchor.constraint(equalTo: mapView.bottomAnchor, constant: -100)
-            // TODO: bottom constraints 필요
+            moreStoreButton.widthAnchor.constraint(equalToConstant: 97),
+            moreStoreButtonBottomConstraint
         ])
+    }
+    
+    func changeButtonsConstraints(delay: Bool) {
+        guard let controller = storeInformationViewController.sheetPresentationController else { return }
+        if controller.detents.contains(.smallSummaryViewDetent) {
+            refreshButtonBottomConstraint.constant = -260
+            locationButtonBottomConstraint.constant = -260
+            moreStoreButtonBottomConstraint.constant = -260
+        } else {
+            refreshButtonBottomConstraint.constant = -283
+            locationButtonBottomConstraint.constant = -283
+            moreStoreButtonBottomConstraint.constant = -283
+        }
+        UIView.animate(withDuration: 0.3, delay: delay ? 0.5 : 0) {
+            self.view.layoutIfNeeded()
+        }
     }
     
 }
@@ -629,6 +658,9 @@ extension HomeViewController: NMFMapViewCameraDelegate {
                 sheet.prefersGrabberVisible = true
                 sheet.preferredCornerRadius = 15
             }
+            refreshButtonBottomConstraint.constant = -90
+            locationButtonBottomConstraint.constant = -90
+            moreStoreButtonBottomConstraint.constant = -90
             present(storeListViewController, animated: true)
         }
     }

--- a/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
@@ -90,6 +90,7 @@ private extension StoreListViewController {
     func setup() {
         isModalInPresentation = true
         storeTableView.delegate = self
+        view.backgroundColor = .white
     }
     
     func addUIComponents() {
@@ -99,9 +100,10 @@ private extension StoreListViewController {
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            titleBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            titleBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
             titleBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            titleBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+            titleBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            titleBar.heightAnchor.constraint(equalToConstant: 65)
         ])
         
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## ⭐️ Issue Number

- #170

## 🚩 Summary

- StoreListViewController TitleBar 크기 변경
- LocationButton, RefreshButton, MoreStoreButton, NaverLogoMargin 애니메이션 및 Constraints 변화 구현

![Simulator Screen Recording - iPhone 15 Pro - 2024-02-07 at 04 27 51](https://github.com/Korea-Certified-Store/iOS/assets/128480641/7a051f99-2ec8-4b1e-9f1d-68b08b284308)


## 🛠️ Technical Concerns

### 서로 다른 UIViewController의 Constraints 
HomeViewController에 present되어있는 StoreListViewController와 StoreInformationViewController 위에 LocationButton, RefreshButton, MoreStoreButton, NaverLogoMargin 이렇게 4가지 버튼이 위에 붙어있어야 했다.
하지만 서로 다른 ViewController끼리 Constraints를 설정하는 것이 불가능했다.
그래서 present할 때의 detents를 기준으로 HomeViewController에서만 Constraints를 설정하여 해결했다.
