### PR TITLE
재검색 버튼 비활성화 다크모드 대응

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -1209,6 +1209,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1246,6 +1247,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -14,7 +14,7 @@ final class MoreStoreButton: UIButton {
             if isEnabled {
                 configuration?.baseForegroundColor = .black
             } else {
-                configuration?.baseForegroundColor = .grayLabel
+                configuration?.baseForegroundColor = .gray
             }
         }
     }

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -14,7 +14,7 @@ final class MoreStoreButton: UIButton {
             if isEnabled {
                 configuration?.baseForegroundColor = .black
             } else {
-                configuration?.baseForegroundColor = .gray
+                configuration?.baseForegroundColor = .grayLabel
             }
         }
     }

--- a/KCS/KCS/Resource/Info.plist
+++ b/KCS/KCS/Resource/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>DEV_SERVER_URL</key>
 	<string>$(DEV_SERVER_URL)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NMAP_CLIENT_ID</key>
 	<string>$(NMAP_CLIENT_ID)</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## ⭐️ Issue Number

- #177

## 🚩 Summary

- 앱 Appearance Light 모드로 고정

## 🛠️ Technical Concerns

### 다크모드

UIButton의 isEnabled가 false인 경우의 색상이 다크모드와 일반모드가 다르다. 
그래서 그것을 통일하기 위해서 모든 버튼와 라벨을 신경쓰고 있었다.
하지만 지도 자체가 이미 색이 밝아서 다크모드가 의미가 없다고 판단되어 앱 자체 Appearance를 Light로 고정했다.
