### PR TITLE
가게가 없을 때 필터 버튼 동작 에러 수정

### DIFF
--- a/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreRepositoryImpl.swift
@@ -72,6 +72,7 @@ final class StoreRepositoryImpl: StoreRepository {
     }
     
     func fetchStores(count: Int) -> [Store] {
+        if stores.isEmpty { return [] }
         var fetchResult: [Store] = []
         for index in 0..<count {
             fetchResult.append(contentsOf: stores[index])


### PR DESCRIPTION
## ⭐️ Issue Number

- #187 

## 🚩 Summary

- 가게가 없는 곳에서 필터 버튼을 누르면 발생하는 Error 해결

![Simulator Screen Recording - iPhone 15 - 2024-02-08 at 20 35 43](https://github.com/Korea-Certified-Store/iOS/assets/62226667/b6f51ac6-cb42-456a-9a8d-4285c031f899)

