### PR TITLE
검색 SearchViewController 구현

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		591A88892B384E610059E40F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 591A88872B384E610059E40F /* LaunchScreen.storyboard */; };
 		592262242B61203000CA5A11 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592262232B61203000CA5A11 /* DetailView.swift */; };
 		59503A4A2B741F1E0006CF35 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 59503A492B741F1E0006CF35 /* Secret.xcconfig */; };
+		59503A4E2B751B0B0006CF35 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A4D2B751B0B0006CF35 /* SearchViewController.swift */; };
+		59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A512B751FCC0006CF35 /* SearchViewModel.swift */; };
+		59503A542B751FD50006CF35 /* SearchViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A532B751FD50006CF35 /* SearchViewModelImpl.swift */; };
 		595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */; };
 		596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
@@ -144,6 +147,9 @@
 		591A888A2B384E610059E40F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		592262232B61203000CA5A11 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		59503A492B741F1E0006CF35 /* Secret.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
+		59503A4D2B751B0B0006CF35 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		59503A512B751FCC0006CF35 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		59503A532B751FD50006CF35 /* SearchViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelImpl.swift; sourceTree = "<group>"; };
 		595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertMessage.swift; sourceTree = "<group>"; };
 		596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewContents.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
@@ -311,6 +317,40 @@
 			path = KCS;
 			sourceTree = "<group>";
 		};
+		59503A4B2B751AEE0006CF35 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				59503A4C2B751AFD0006CF35 /* View */,
+				59503A4F2B751FB30006CF35 /* ViewModel */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		59503A4C2B751AFD0006CF35 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				59503A4D2B751B0B0006CF35 /* SearchViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		59503A4F2B751FB30006CF35 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				59503A502B751FBE0006CF35 /* Protocol */,
+				59503A532B751FD50006CF35 /* SearchViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		59503A502B751FBE0006CF35 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				59503A512B751FCC0006CF35 /* SearchViewModel.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		5977BE592B55355D00725C90 /* protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -407,6 +447,7 @@
 		5986DCDF2B3892EB005AE43B /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				59503A4B2B751AEE0006CF35 /* Search */,
 				A890870B2B4EF8F900767225 /* Extension */,
 				5986DCEA2B392996005AE43B /* Home */,
 				59B886242B6A39E9005750EF /* StoreList */,
@@ -1034,7 +1075,9 @@
 				A821A37C2B74BC4B00089B8F /* CheckNetworkStatusUseCase.swift in Sources */,
 				A8A7E05D2B64AF1300D015E5 /* StoreInformationViewConstraints.swift in Sources */,
 				5977BE5E2B5535C700725C90 /* FetchRefreshStoresUseCase.swift in Sources */,
+				59503A4E2B751B0B0006CF35 /* SearchViewController.swift in Sources */,
 				A83367BB2B709C0200E0A844 /* OnboardingViewController.swift in Sources */,
+				59503A542B751FD50006CF35 /* SearchViewModelImpl.swift in Sources */,
 				A83367B62B6F993F00E0A844 /* MoreStoreButton.swift in Sources */,
 				59C306B02B4FFE4400862625 /* StoreResponse.swift in Sources */,
 				A8A7E0602B64E62200D015E5 /* NMFMyPosition+.swift in Sources */,
@@ -1060,6 +1103,7 @@
 				59C306CF2B50399C00862625 /* RequestLocationDTO.swift in Sources */,
 				A83367C32B72714C00E0A844 /* ThirdOnboardingView.swift in Sources */,
 				A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */,
+				59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */,
 				A8ACB7D82B57BE7D00540BD1 /* StoreRepositoryError.swift in Sources */,
 				59B8864A2B6A9CCB005750EF /* UIStackView+clear.swift in Sources */,
 				59C306C72B501B1E00862625 /* JSONContentsError.swift in Sources */,

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -67,7 +67,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             ), rootViewController: rootViewController
         )
         
-        window?.rootViewController = splashViewController
+//        window?.rootViewController = splashViewController
+        
+        window?.rootViewController = UINavigationController(rootViewController: SearchViewController(viewModel: SearchViewModelImpl(), searchObserver: PublishRelay<String>()))
         window?.makeKeyAndVisible()
     }
     

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -67,9 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             ), rootViewController: rootViewController
         )
         
-//        window?.rootViewController = splashViewController
-        
-        window?.rootViewController = UINavigationController(rootViewController: SearchViewController(viewModel: SearchViewModelImpl(), searchObserver: PublishRelay<String>()))
+        window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()
     }
     

--- a/KCS/KCS/Presentation/Extension/UIViewController+Alert.swift
+++ b/KCS/KCS/Presentation/Extension/UIViewController+Alert.swift
@@ -35,7 +35,6 @@ extension UIViewController {
         requestLocationServiceAlert.addAction(cancel)
         requestLocationServiceAlert.addAction(goSetting)
         
-        
         if let presentController = presentedViewController {
             presentController.presentLocationAlert()
         } else {

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -89,6 +89,10 @@ final class SearchViewController: UIViewController {
         
         searchController.searchBar.becomeFirstResponder()
     }
+    
+    func setSearchKeyword(keyword: String) {
+        searchController.searchBar.searchTextField.text = keyword
+    }
 
 }
 

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -1,0 +1,156 @@
+//
+//  SearchViewController.swift
+//  KCS
+//
+//  Created by 조성민 on 2/8/24.
+//
+
+import UIKit
+import RxSwift
+import RxRelay
+
+final class SearchViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    
+    private lazy var searchController: UISearchController = {
+        let searchController = UISearchController(searchResultsController: nil)
+        searchController.searchBar.placeholder = "검색어를 입력하세요"
+        searchController.hidesNavigationBarDuringPresentation = false
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.automaticallyShowsCancelButton = false
+        searchController.searchBar.delegate = self
+        
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        
+        return searchController
+    }()
+    
+    private lazy var searchTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: UITableViewCell.identifier)
+        tableView.backgroundColor = .white
+        // TODO: 디자인에 맞춰야 함
+        tableView.rowHeight = 50
+        
+        return tableView
+    }()
+    
+    enum Section {
+        case keyword
+    }
+    
+    private lazy var dataSource: UITableViewDiffableDataSource<Section, String> = {
+        return UITableViewDiffableDataSource<Section, String>(
+            tableView: searchTableView
+        ) { (tableView, indexPath, keyword) in
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: UITableViewCell.identifier,
+                for: indexPath
+            )
+            cell.selectionStyle = .none
+            var configuration = cell.defaultContentConfiguration()
+            configuration.text = keyword
+            cell.contentConfiguration = configuration
+            
+            return cell
+        }
+    }()
+    
+    private let searchObserver: PublishRelay<String>
+    private let viewModel: SearchViewModel
+    
+    init(viewModel: SearchViewModel, searchObserver: PublishRelay<String>) {
+        self.viewModel = viewModel
+        self.searchObserver = searchObserver
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addUIComponents()
+        configureConstraints()
+        bind()
+        setup()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        searchController.searchBar.becomeFirstResponder()
+    }
+
+}
+
+private extension SearchViewController {
+    
+    func setup() {
+        view.backgroundColor = .white
+        searchController.isActive = true
+    }
+    
+    func addUIComponents() {
+        view.addSubview(searchTableView)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            searchTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            searchTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            searchTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            searchTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    func bind() {
+        viewModel.generateDataOutput
+            .bind { [weak self] data in
+                self?.generateData(data: data)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}
+
+private extension SearchViewController {
+    
+    func generateData(data: [String]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, String>()
+        snapshot.appendSections([.keyword])
+        snapshot.appendItems(data)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
+    
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let text = searchController.searchBar.text else { return }
+        viewModel.action(input: .textChanged(text: text))
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let text = searchBar.text else { return }
+        searchObserver.accept(text)
+    }
+    
+}
+
+extension SearchViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let text = dataSource.itemIdentifier(for: indexPath) else { return }
+        searchObserver.accept(text)
+    }
+    
+}

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  SearchViewModel.swift
+//  KCS
+//
+//  Created by 조성민 on 2/8/24.
+//
+
+import RxRelay
+
+protocol SearchViewModel: SearchViewModelInput, SearchViewModelOutput {
+    
+}
+
+protocol SearchViewModelInput {
+    
+    func action(input: SearchViewModelInputCase)
+    
+}
+
+enum SearchViewModelInputCase {
+    
+    case textChanged(text: String)
+    
+}
+
+protocol SearchViewModelOutput {
+    
+    var generateDataOutput: PublishRelay<[String]> { get }
+    
+}

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -25,10 +25,8 @@ private extension SearchViewModelImpl {
     func textChanged(text: String) {
         if text.isEmpty {
             // TODO: recentHistory usecase 실행(debounce) 후 generateDataOutput.accept([])
-            generateDataOutput.accept(["recentHistory1", "recentHistory2", "recentHistory3", "recentHistory4"])
         } else {
             // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([])
-            generateDataOutput.accept(["completion1", "completion2", "completion3"])
         }
     }
     

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -1,0 +1,35 @@
+//
+//  SearchViewModelImpl.swift
+//  KCS
+//
+//  Created by 조성민 on 2/8/24.
+//
+
+import RxRelay
+
+final class SearchViewModelImpl: SearchViewModel {
+    
+    var generateDataOutput = PublishRelay<[String]>()
+    
+    func action(input: SearchViewModelInputCase) {
+        switch input {
+        case .textChanged(let text):
+            textChanged(text: text)
+        }
+    }
+    
+}
+
+private extension SearchViewModelImpl {
+    
+    func textChanged(text: String) {
+        if text.isEmpty {
+            // TODO: recentHistory usecase 실행(debounce) 후 generateDataOutput.accept([])
+            generateDataOutput.accept(["recentHistory1", "recentHistory2", "recentHistory3", "recentHistory4"])
+        } else {
+            // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([])
+            generateDataOutput.accept(["completion1", "completion2", "completion3"])
+        }
+    }
+    
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #194

## 🚩 Summary

- Search ViewController 구현
- Search ViewModel 틀 구현

![Simulator Screen Recording - iPhone 15 - 2024-02-09 at 04 11 13](https://github.com/Korea-Certified-Store/iOS/assets/128480641/008ed53b-b3dd-43b5-b745-fe4e1be7d1f6)

## 🛠️ Technical Concerns

### 검색 플로우

1. 검색을 처음 시작하는 경우
    - 검색창을 누르지 않아도 선택된 상태로 할 수 있도록 설정했다. 
2. 검색어가 있는 상태에서 시작하는 경우
    - 외부에서 미리 searchBar에 키워드를 설정할 수 있도록 함수를 만들었다.
    ```swift
    func setSearchKeyword(keyword: String) {
    searchController.searchBar.searchTextField.text = keyword
    }
    ```
3. 검색어를 입력하는 경우
    - 검색어를 입력하는 경우 검색어가 변경될 때마다 viewModel.action()을 이용하여 신호를 보낸다.
    - 이때 신호는 ViewModel에서 로직에 따라 빈 문자열인 경우 최근 검색어 문자열의 배열을 받아오고, 빈 문자열이 아닌 경우 자동완성 문자열의 배열을 받아온다.
    - 추후에 해결할 사항으로 API 콜을 줄이기 위해서 UseCase를 실행시킬 때 debounce를 사용해야 한다.
4. 검색을 실행시킨 경우 & 자동완성 검색어를 선택한 경우 & 최근 검색어를 선택한 경우
    - 모두 검색을 실행시키는 것으로 검색 SearchViewModel이 처리하여 [Store]를 HomeViewController에 넘겨주는 것보다 신호만 넘겨주고 HomeViewModel이 처리하는 것이 플로우가 자연스럽다고 판단하여 searchObserver.accept()를 이용하여 HomeViewModel이 처리할 수 있도록 했다.

## 🙂 To Reviwer

- ViewController에서 검색하거나 텍스트가 변경될 때 어떻게 ViewModel로 넘어가는지 확인해보시면 좋을 것 같습니다.

## 📋 To Do

- HomeViewController가 SearchViewController가 보내는 신호를 처리해야 한다.
