### PR TITLE
Update Notification

### DIFF
--- a/KCS/KCS/Presentation/Splash/ViewModel/SplashViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Splash/ViewModel/SplashViewModelImpl.swift
@@ -59,7 +59,6 @@ private extension SplashViewModelImpl {
             results.count > 0,
             let appStoreVersion = results[0]["version"] as? String
         else { return false }
-        print("\(version), \(appStoreVersion)")
         if !(version == appStoreVersion) { return true }
         return false
     }

--- a/KCS/KCS/Presentation/Splash/ViewModel/SplashViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Splash/ViewModel/SplashViewModelImpl.swift
@@ -13,6 +13,8 @@ final class SplashViewModelImpl: SplashViewModel {
     
     let networkEnableOutput = PublishRelay<Void>()
     let networkDisableOutput = PublishRelay<Void>()
+    var needToUpdateOutput = PublishRelay<Void>()
+    var noNeedToUpdateOutput = PublishRelay<Void>()
     
     init(checkNetworkStatusUseCase: CheckNetworkStatusUseCase) {
         self.checkNetworkStatusUseCase = checkNetworkStatusUseCase
@@ -22,6 +24,8 @@ final class SplashViewModelImpl: SplashViewModel {
         switch action {
         case .checkNetworkInput:
             checkNetworkInput()
+        case .checkUpdateInput:
+            checkUpdateInput()
         }
     }
     
@@ -35,6 +39,29 @@ private extension SplashViewModelImpl {
         } else {
             networkDisableOutput.accept(())
         }
+    }
+    
+    func checkUpdateInput() {
+        if isUpdateAvailable() {
+            needToUpdateOutput.accept(())
+        } else {
+            noNeedToUpdateOutput.accept(())
+        }
+    }
+    
+    func isUpdateAvailable() -> Bool {
+        guard
+            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+            let url = URL(string: "http://itunes.apple.com/lookup?bundleId=6476478078"),
+            let data = try? Data(contentsOf: url),
+            let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+            let results = json["results"] as? [[String: Any]],
+            results.count > 0,
+            let appStoreVersion = results[0]["version"] as? String
+        else { return false }
+        print("\(version), \(appStoreVersion)")
+        if !(version == appStoreVersion) { return true }
+        return false
     }
     
 }

--- a/KCS/KCS/Presentation/Splash/ViewModel/protocol/SplashViewModel.swift
+++ b/KCS/KCS/Presentation/Splash/ViewModel/protocol/SplashViewModel.swift
@@ -22,6 +22,7 @@ protocol SplashViewModelInput {
 enum SplashViewModelInputCase {
     
     case checkNetworkInput
+    case checkUpdateInput
     
 }
 
@@ -29,5 +30,7 @@ protocol SplashViewModelOutput {
     
     var networkEnableOutput: PublishRelay<Void> { get }
     var networkDisableOutput: PublishRelay<Void> { get }
+    var needToUpdateOutput: PublishRelay<Void> { get }
+    var noNeedToUpdateOutput: PublishRelay<Void> { get }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #203

## 🚩 Summary

- Update Alert 구현

업데이트 버튼을 눌러도 다시 업데이트 Alert가 뜨도록 구현했다.
업데이트가 필요하지 않으면 넘어간다.

https://github.com/Korea-Certified-Store/iOS/assets/128480641/7ae7438b-88b9-4320-aebb-5a1921757999

## 🛠️ Technical Concerns

### URL 데이터 스레드

URL을 통해서 데이터를 받아 오는 일은 main 스레드에서 이뤄지면 안 된다. 
AppVersion을 체크하는 일을 다른 스레드에서 처리해줘야 했다. 
한번 thread가 변경되면 main으로 변경해줘야 했다.
