### PR TITLE
가게리스트 선택 오류 수정

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -207,9 +207,8 @@ final class HomeViewController: UIViewController {
         
         addUIComponents()
         configureConstraints()
-        bind()
         setup()
-        refresh()
+        bind()
     }
     
 }
@@ -313,6 +312,12 @@ private extension HomeViewController {
                 self?.locationButton.setImage(UIImage(named: imageName), for: .normal)
             }
             .disposed(by: disposeBag)
+        
+        viewModel.requestLocationAuthorizationOutput
+            .bind { [weak self] in
+                self?.presentLocationAlert()
+            }
+            .disposed(by: disposeBag)
     }
     
     func bindStoreInformationView() {
@@ -360,22 +365,21 @@ private extension HomeViewController {
     
     func bindLocationAuthorization() {
         viewModel.locationAuthorizationStatusDeniedOutput
-            .bind { [weak self] _ in
-                guard let self = self else { return }
-                presentLocationAlert()
+            .bind { [weak self] in
+                self?.refresh()
             }
             .disposed(by: disposeBag)
         
         viewModel.locationStatusNotDeterminedOutput
-            .bind { [weak self] _ in
+            .bind { [weak self] in
                 self?.locationManager.requestWhenInUseAuthorization()
                 self?.locationButton.setImage(UIImage.locationButtonNone, for: .normal)
             }
             .disposed(by: disposeBag)
         
-        viewModel.locationStatusAuthorizedWhenInUse
+        viewModel.locationStatusAuthorizedWhenInUseOutput
             .debounce(.milliseconds(10), scheduler: MainScheduler())
-            .bind { [weak self] _ in
+            .bind { [weak self] in
                 guard let self = self else { return }
                 guard let location = locationManager.location else { return }
                 let cameraUpdate = NMFCameraUpdate(

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -23,7 +23,8 @@ final class HomeViewModelImpl: HomeViewModel {
     let setMarkerOutput = PublishRelay<MarkerContents>()
     let locationAuthorizationStatusDeniedOutput = PublishRelay<Void>()
     let locationStatusNotDeterminedOutput = PublishRelay<Void>()
-    let locationStatusAuthorizedWhenInUse = PublishRelay<Void>()
+    let locationStatusAuthorizedWhenInUseOutput = PublishRelay<Void>()
+    let requestLocationAuthorizationOutput = PublishRelay<Void>()
     let errorAlertOutput = PublishRelay<ErrorAlertMessage>()
     let filteredStoresOutput = PublishRelay<[FilteredStores]>()
     let fetchCountOutput = PublishRelay<FetchCountContent>()
@@ -213,7 +214,7 @@ private extension HomeViewModelImpl {
     
     func locationButtonTapped(locationAuthorizationStatus: CLAuthorizationStatus, positionMode: NMFMyPositionMode) {
         if locationAuthorizationStatus == .denied {
-            locationAuthorizationStatusDeniedOutput.accept(())
+            requestLocationAuthorizationOutput.accept(())
         }
         switch positionMode {
         case .direction:
@@ -234,9 +235,9 @@ private extension HomeViewModelImpl {
         case .notDetermined:
             locationStatusNotDeterminedOutput.accept(())
         case .authorizedWhenInUse:
-            locationStatusAuthorizedWhenInUse.accept(())
+            locationStatusAuthorizedWhenInUseOutput.accept(())
         default:
-            break
+            locationAuthorizationStatusDeniedOutput.accept(())
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -55,7 +55,8 @@ protocol HomeViewModelOutput {
     var setMarkerOutput: PublishRelay<MarkerContents> { get }
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }
-    var locationStatusAuthorizedWhenInUse: PublishRelay<Void> { get }
+    var locationStatusAuthorizedWhenInUseOutput: PublishRelay<Void> { get }
+    var requestLocationAuthorizationOutput: PublishRelay<Void> { get }
     var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
     var fetchCountOutput: PublishRelay<FetchCountContent> { get }
     var noMoreStoresOutput: PublishRelay<Void> { get }


### PR DESCRIPTION
## ⭐️ Issue Number

- #208 

## 🚩 Summary

- 현위치에서 가게 리스트 및 마커가 잘못뜨는 Error를 고친다.

## 🛠️ Technical Concerns

### Refresh의 타이밍

위치 권한을 확인하고 가게 리스트를 불러오는 refresh함수를 호출하는 과정에서 sequence가 맞지 않아 발생한 Error였다.
refresh를 viewDidLoad에서 해주지 않고 위치 권한 확인이 끝난 시점에서 해주도록 코드를 수정하여 해당 Error를 수정하였다.