### PR TITLE
재검색 최대 범위 설정

### DIFF
--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import RxRelay
+import NMapsMap
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -54,12 +55,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             )
         )
         let searchObserver = PublishRelay<String>()
+        let refreshCameraPositionObserver = BehaviorRelay<NMFCameraPosition>(value: NMFCameraPosition())
         let searchKeywordRepository = SearchKeywordRepositoryImpl(
             userDefaults: UserDefaults()
         )
         let homeViewController = HomeViewController(
             viewModel: viewModel,
-            storeInformationViewController: storeInformationViewController,
             storeListViewController: StoreListViewController(
                 viewModel: StoreListViewModelImpl(
                     fetchImageUseCase: FetchImageUseCaseImpl(
@@ -68,8 +69,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 ),
                 listCellSelectedObserver: listCellSelectedObserver
             ),
-            summaryViewHeightObserver: summaryViewHeightObserver,
-            listCellSelectedObserver: listCellSelectedObserver,
+            storeInformationViewController: storeInformationViewController,
             searchViewController: SearchViewController(
                 viewModel: SearchViewModelImpl(
                     fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCaseImpl(
@@ -77,14 +77,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     ),
                     saveRecentSearchKeywordUseCase: SaveRecentSearchKeywordUseCaseImpl(
                         repository: searchKeywordRepository
-                    ), 
+                    ),
                     deleteRecentSearchKeywordUseCase: DeleteRecentSearchKeywordUseCaseImpl(
                         repository: searchKeywordRepository
                     )
                 ),
                 searchObserver: searchObserver
-            ),
-            searchObserver: searchObserver
+            ), 
+            summaryViewHeightObserver: summaryViewHeightObserver,
+            listCellSelectedObserver: listCellSelectedObserver,
+            searchObserver: searchObserver, 
+            refreshCameraPositionObserver: refreshCameraPositionObserver
         )
         
         var rootViewController: UIViewController

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -220,32 +220,32 @@ final class HomeViewController: UIViewController {
         equalTo: mapView.bottomAnchor, constant: -90
     )
     
+    private let viewModel: HomeViewModel
+    private let storeListViewController: StoreListViewController
+    private let storeInformationViewController: StoreInformationViewController
     private let searchViewController: SearchViewController
+    private let summaryViewHeightObserver: PublishRelay<SummaryViewHeightCase>
+    private let listCellSelectedObserver: PublishRelay<Int>
     private let searchObserver: PublishRelay<String>
     private let disposeBag = DisposeBag()
     private var markers: [Marker] = []
-    private let storeInformationViewController: StoreInformationViewController
     private var clickedMarker: Marker?
-    private let storeListViewController: StoreListViewController
-    private let viewModel: HomeViewModel
-    private let summaryViewHeightObserver: PublishRelay<SummaryViewHeightCase>
-    private let listCellSelectedObserver: PublishRelay<Int>
     
     init(
         viewModel: HomeViewModel,
-        storeInformationViewController: StoreInformationViewController,
         storeListViewController: StoreListViewController,
+        storeInformationViewController: StoreInformationViewController,
+        searchViewController: SearchViewController,
         summaryViewHeightObserver: PublishRelay<SummaryViewHeightCase>,
         listCellSelectedObserver: PublishRelay<Int>,
-        searchViewController: SearchViewController,
         searchObserver: PublishRelay<String>
     ) {
         self.viewModel = viewModel
-        self.storeInformationViewController = storeInformationViewController
         self.storeListViewController = storeListViewController
+        self.storeInformationViewController = storeInformationViewController
+        self.searchViewController = searchViewController
         self.summaryViewHeightObserver = summaryViewHeightObserver
         self.listCellSelectedObserver = listCellSelectedObserver
-        self.searchViewController = searchViewController
         self.searchObserver = searchObserver
         
         super.init(nibName: nil, bundle: nil)
@@ -647,6 +647,7 @@ private extension HomeViewController {
                 requestLocation: makeRequestLocation(projection: mapView.mapView.projection)
             )
         )
+        
     }
     
     func setBackStoreListButton(row: Int) {
@@ -658,6 +659,25 @@ private extension HomeViewController {
         searchViewController.setSearchKeyword(keyword: searchBarView.searchTextField.text)
         if let presentedViewController = presentedViewController {
             presentedViewController.present(searchViewController, animated: false)
+        }
+    }
+    
+    func presentStoreListView() {
+        if !(presentedViewController is StoreListViewController) {
+            if let sheet = storeListViewController.sheetPresentationController {
+                sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
+                sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
+                sheet.prefersGrabberVisible = true
+                sheet.preferredCornerRadius = 15
+            }
+            refreshButtonBottomConstraint.constant = -90
+            locationButtonBottomConstraint.constant = -90
+            moreStoreButtonBottomConstraint.constant = -90
+            mapView.mapView.logoMargin.bottom = 55
+            UIView.animate(withDuration: 0.5) {
+                self.view.layoutIfNeeded()
+            }
+            present(storeListViewController, animated: true)
         }
     }
     
@@ -813,23 +833,8 @@ extension HomeViewController: NMFMapViewCameraDelegate {
         }
     }
     
-    func presentStoreListView() {
-        if !(presentedViewController is StoreListViewController) {
-            if let sheet = storeListViewController.sheetPresentationController {
-                sheet.detents = [.smallStoreListViewDetent, .largeStoreListViewDetent]
-                sheet.largestUndimmedDetentIdentifier = .smallStoreListViewDetentIdentifier
-                sheet.prefersGrabberVisible = true
-                sheet.preferredCornerRadius = 15
-            }
-            refreshButtonBottomConstraint.constant = -90
-            locationButtonBottomConstraint.constant = -90
-            moreStoreButtonBottomConstraint.constant = -90
-            mapView.mapView.logoMargin.bottom = 55
-            UIView.animate(withDuration: 0.5) {
-                self.view.layoutIfNeeded()
-            }
-            present(storeListViewController, animated: true)
-        }
+    func mapViewCameraIdle(_ mapView: NMFMapView) {
+        print("end move : \(mapView.cameraPosition)")
     }
     
 }
@@ -838,6 +843,7 @@ extension HomeViewController: NMFMapViewTouchDelegate {
     
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         storeInformationViewDismiss()
+        dump(mapView.cameraPosition)
     }
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -437,7 +437,7 @@ private extension HomeViewController {
             }
             .disposed(by: disposeBag)
         
-        viewModel.locationStatusAuthorizedWhenInUse
+        viewModel.locationStatusAuthorizedWhenInUseOutput
             .debounce(.milliseconds(10), scheduler: MainScheduler())
             .bind { [weak self] _ in
                 guard let self = self else { return }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -24,7 +24,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let setMarkerOutput = PublishRelay<MarkerContents>()
     let locationAuthorizationStatusDeniedOutput = PublishRelay<Void>()
     let locationStatusNotDeterminedOutput = PublishRelay<Void>()
-    let locationStatusAuthorizedWhenInUse = PublishRelay<Void>()
+    let locationStatusAuthorizedWhenInUseOutput = PublishRelay<Void>()
     let errorAlertOutput = PublishRelay<ErrorAlertMessage>()
     let filteredStoresOutput = PublishRelay<[FilteredStores]>()
     let fetchCountOutput = PublishRelay<FetchCountContent>()
@@ -251,7 +251,7 @@ private extension HomeViewModelImpl {
         case .notDetermined:
             locationStatusNotDeterminedOutput.accept(())
         case .authorizedWhenInUse:
-            locationStatusAuthorizedWhenInUse.accept(())
+            locationStatusAuthorizedWhenInUseOutput.accept(())
         default:
             break
         }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -32,6 +32,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let dimViewTapGestureEndedOutput = PublishRelay<Void>()
     let searchStoresOutput = PublishRelay<[Store]>()
     let searchOneStoreOutput = PublishRelay<Store>()
+    let moreStoreButtonHiddenOutput = PublishRelay<Void>()
     
     var dependency: HomeDependency
     
@@ -73,6 +74,13 @@ final class HomeViewModelImpl: HomeViewModel {
             search(location: location, keyword: keyword)
         case .resetFilters:
             resetFilters()
+        case .compareCameraPosition(let refreshCameraPosition, let endMoveCameraPosition, let refreshCameraPoint, let endMoveCameraPoint):
+            compareCameraPosition(
+                refreshCameraPosition: refreshCameraPosition,
+                endMoveCameraPosition: endMoveCameraPosition,
+                refreshCameraPoint: refreshCameraPoint,
+                endMoveCameraPoint: endMoveCameraPoint
+            )
         }
     }
     
@@ -278,6 +286,22 @@ private extension HomeViewModelImpl {
     
     func resetFilters() {
         dependency.activatedFilter = []
+    }
+    
+    func compareCameraPosition(
+        refreshCameraPosition: NMFCameraPosition,
+        endMoveCameraPosition: NMFCameraPosition,
+        refreshCameraPoint: CGPoint,
+        endMoveCameraPoint: CGPoint
+    ) {
+        let zoomDifference = abs(refreshCameraPosition.zoom - endMoveCameraPosition.zoom)
+        let pointDifference = sqrt(
+            pow(refreshCameraPoint.x - endMoveCameraPoint.x, 2) +
+            pow(refreshCameraPoint.y - endMoveCameraPoint.y, 2)
+        )
+        if zoomDifference > 0.5 || pointDifference > 50 {
+            moreStoreButtonHiddenOutput.accept(())
+        }
     }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -40,6 +40,12 @@ enum HomeViewModelInputCase {
     case checkLocationAuthorizationWhenCameraDidChange(status: CLAuthorizationStatus)
     case search(location: Location, keyword: String)
     case resetFilters
+    case compareCameraPosition(
+        refreshCameraPosition: NMFCameraPosition,
+        endMoveCameraPosition: NMFCameraPosition,
+        refreshCameraPoint: CGPoint,
+        endMoveCameraPoint: CGPoint
+    )
     
 }
 
@@ -66,5 +72,6 @@ protocol HomeViewModelOutput {
     var dimViewTapGestureEndedOutput: PublishRelay<Void> { get }
     var searchStoresOutput: PublishRelay<[Store]> { get }
     var searchOneStoreOutput: PublishRelay<Store> { get }
+    var moreStoreButtonHiddenOutput: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -65,7 +65,7 @@ protocol HomeViewModelOutput {
     var setMarkerOutput: PublishRelay<MarkerContents> { get }
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }
-    var locationStatusAuthorizedWhenInUse: PublishRelay<Void> { get }
+    var locationStatusAuthorizedWhenInUseOutput: PublishRelay<Void> { get }
     var errorAlertOutput: PublishRelay<ErrorAlertMessage> { get }
     var fetchCountOutput: PublishRelay<FetchCountContent> { get }
     var noMoreStoresOutput: PublishRelay<Void> { get }


### PR DESCRIPTION
## ⭐️ Issue Number

- #206 

## 🚩 Summary

- 화면 이동 시 현 위치 재검색이 나올 수 있는 이동 범위를 설정한다
- HomeViewController의 변수 선언 순서를 재정렬한다
- HomeViewModel의 `locationStatusAuthorizedWhenInUse`의 변수명을 수정한다

|![Simulator Screen Recording - iPhone 15 - 2024-02-12 at 01 25 09](https://github.com/Korea-Certified-Store/iOS/assets/62226667/54786257-9e04-4a37-880b-93fdb8b7b600)|![Simulator Screen Recording - iPhone 15 - 2024-02-12 at 01 25 37](https://github.com/Korea-Certified-Store/iOS/assets/62226667/3ec249bd-a188-43f1-925e-054f9ec90e6e)|
|:--:|:--:|
|화면 상 CGPoint 50이상 이동 시 버튼 Change|Zoom 레벨 0.5이상 차이나는 경우 버튼 Change|


## 🛠️ Technical Concerns

### Zoom 레벨과 CGPoint

사용자가 지도를 이동시켰을 때, 이동시키기 직전의 위치와 이동시킨 후 위치를 비교해야했다.
참고용으로 사용한 카카오맵의 경우, 실제 거리가 아닌 화면상 특정 길이 이상을 움직이면 버튼이 바뀌도록 설정이 되어있었다. 이를 구현하기 위해 다음 두가지의 비교군이 필요했다.

- 카메라의 확대/축소
- 화면상 움직인 거리

먼저 카메라의 확대/축소를 비교하기 위해서 NAVER Map API에서 제공하는 `cameraPosition.zoom`을 사용하였다.
화면상 움직인 거리는 카메라가 비추는 위치를 화면 상 CGPoint로 변환시켜주는 NAVER Map API 제공 메서드인 `-pointFromLatLng:`를 사용하여 측정하고 비교할 수 있었다.

실제로 이동시키면서 실험해본 결과 적당한 값으로 Zoom 레벨은 0.5 이상, 화면상 거리는 50pt 이상 차이나는 경우 버튼이 바뀌도록 구현해주었다.

