### PR TITLE
최근 검색어, 자동완성 Cell Layout 구현

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		59503A5C2B75927F0006CF35 /* SearchStoreResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A5B2B75927F0006CF35 /* SearchStoreResponse.swift */; };
 		59503A5E2B7596990006CF35 /* GetSearchStoresUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A5D2B7596990006CF35 /* GetSearchStoresUseCase.swift */; };
 		59503A602B75970E0006CF35 /* GetSearchStoresUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A5F2B75970E0006CF35 /* GetSearchStoresUseCaseImpl.swift */; };
+		59503A662B791C940006CF35 /* RecentHistoryHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */; };
+		59503A682B79253B0006CF35 /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A672B79253B0006CF35 /* UITableViewCell+Identifier.swift */; };
+		59503A6A2B7946D30006CF35 /* RecentHistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */; };
 		595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */; };
 		596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
@@ -43,7 +46,6 @@
 		598CC4DD2B5D44940043D064 /* MockFailStoreRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CC4DC2B5D44940043D064 /* MockFailStoreRepository.swift */; };
 		59B886262B6A3A02005750EF /* StoreListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B886252B6A3A02005750EF /* StoreListViewController.swift */; };
 		59B886292B6A3F1E005750EF /* StoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B886282B6A3F1E005750EF /* StoreTableViewCell.swift */; };
-		59B8862B2B6A3F7F005750EF /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B8862A2B6A3F7F005750EF /* UITableViewCell+Identifier.swift */; };
 		59B886462B6A5CDC005750EF /* StoreListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B886452B6A5CDC005750EF /* StoreListViewModel.swift */; };
 		59B886482B6A5CE9005750EF /* StoreListViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B886472B6A5CE9005750EF /* StoreListViewModelImpl.swift */; };
 		59B8864A2B6A9CCB005750EF /* UIStackView+clear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B886492B6A9CCB005750EF /* UIStackView+clear.swift */; };
@@ -171,6 +173,9 @@
 		59503A5B2B75927F0006CF35 /* SearchStoreResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStoreResponse.swift; sourceTree = "<group>"; };
 		59503A5D2B7596990006CF35 /* GetSearchStoresUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSearchStoresUseCase.swift; sourceTree = "<group>"; };
 		59503A5F2B75970E0006CF35 /* GetSearchStoresUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSearchStoresUseCaseImpl.swift; sourceTree = "<group>"; };
+		59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryHeaderView.swift; sourceTree = "<group>"; };
+		59503A672B79253B0006CF35 /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
+		59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryTableViewCell.swift; sourceTree = "<group>"; };
 		595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertMessage.swift; sourceTree = "<group>"; };
 		596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewContents.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
@@ -192,7 +197,6 @@
 		598CC4DC2B5D44940043D064 /* MockFailStoreRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFailStoreRepository.swift; sourceTree = "<group>"; };
 		59B886252B6A3A02005750EF /* StoreListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewController.swift; sourceTree = "<group>"; };
 		59B886282B6A3F1E005750EF /* StoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTableViewCell.swift; sourceTree = "<group>"; };
-		59B8862A2B6A3F7F005750EF /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		59B886452B6A5CDC005750EF /* StoreListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewModel.swift; sourceTree = "<group>"; };
 		59B886472B6A5CE9005750EF /* StoreListViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListViewModelImpl.swift; sourceTree = "<group>"; };
 		59B886492B6A9CCB005750EF /* UIStackView+clear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+clear.swift"; sourceTree = "<group>"; };
@@ -362,6 +366,8 @@
 			isa = PBXGroup;
 			children = (
 				59503A4D2B751B0B0006CF35 /* SearchViewController.swift */,
+				59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */,
+				59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -783,7 +789,7 @@
 				A81EFBB42B5D477600D0C0D7 /* UILabel+.swift */,
 				A81EFBC92B5D5A2300D0C0D7 /* UIFont+.swift */,
 				A8A7E05F2B64E62200D015E5 /* NMFMyPosition+.swift */,
-				59B8862A2B6A3F7F005750EF /* UITableViewCell+Identifier.swift */,
+				59503A672B79253B0006CF35 /* UITableViewCell+Identifier.swift */,
 				59B886492B6A9CCB005750EF /* UIStackView+clear.swift */,
 				59B8865F2B6E7CF6005750EF /* UIViewController+Alert.swift */,
 				59B886612B6E8484005750EF /* UISheetPresentationController+Detent.swift */,
@@ -1109,6 +1115,7 @@
 				59C306A62B4D966C00862625 /* CertificationType.swift in Sources */,
 				A890870F2B4F836C00767225 /* SummaryView.swift in Sources */,
 				A802D1F62B5277630091FDE7 /* CertificationLabel.swift in Sources */,
+				59503A662B791C940006CF35 /* RecentHistoryHeaderView.swift in Sources */,
 				59B886262B6A3A02005750EF /* StoreListViewController.swift in Sources */,
 				A83367C72B72725700E0A844 /* FifthOnboardingView.swift in Sources */,
 				5977BE612B55374000725C90 /* HomeViewModel.swift in Sources */,
@@ -1124,6 +1131,7 @@
 				59F478B52B59BE0B002FEF9E /* FetchImageUseCase.swift in Sources */,
 				A8722F042B764679001ED988 /* SaveRecentSearchKeywordUseCaseImpl.swift in Sources */,
 				59C306BF2B50109100862625 /* Location.swift in Sources */,
+				59503A6A2B7946D30006CF35 /* RecentHistoryTableViewCell.swift in Sources */,
 				A8A7E05B2B642EC900D015E5 /* DetailViewContents.swift in Sources */,
 				591A88812B384E600059E40F /* HomeViewController.swift in Sources */,
 				5977BE9C2B59AC8D00725C90 /* ImageRepositoryImpl.swift in Sources */,
@@ -1140,6 +1148,7 @@
 				59C306B02B4FFE4400862625 /* RefreshStoreResponse.swift in Sources */,
 				A8722F022B764620001ED988 /* SaveRecentSearchKeywordUseCase.swift in Sources */,
 				A8A7E0602B64E62200D015E5 /* NMFMyPosition+.swift in Sources */,
+				59503A682B79253B0006CF35 /* UITableViewCell+Identifier.swift in Sources */,
 				A8E53C272B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift in Sources */,
 				A8ACB7EA2B595A3E00540BD1 /* GetOpenClosedUseCaseImpl.swift in Sources */,
 				A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */,
@@ -1151,7 +1160,6 @@
 				5977BE9E2B59ACE800725C90 /* ImageCache.swift in Sources */,
 				59B886642B6EC816005750EF /* SummaryViewHeightCase.swift in Sources */,
 				59C306A42B4D7EBA00862625 /* Marker.swift in Sources */,
-				59B8862B2B6A3F7F005750EF /* UITableViewCell+Identifier.swift in Sources */,
 				59B886462B6A5CDC005750EF /* StoreListViewModel.swift in Sources */,
 				A8E53C2B2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift in Sources */,
 				59B8865E2B6E4B98005750EF /* StoreInformationViewModelImpl.swift in Sources */,
@@ -1381,7 +1389,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = MMM58CZBQF;
+				DEVELOPMENT_TEAM = 7CQAR4CYZX;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
@@ -1399,7 +1407,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.yeonghyeon.nainga;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.nainga;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1420,7 +1428,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MMM58CZBQF;
+				DEVELOPMENT_TEAM = 7CQAR4CYZX;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
@@ -1438,7 +1446,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.yeonghyeon.nainga;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.nainga;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		59503A662B791C940006CF35 /* RecentHistoryHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */; };
 		59503A682B79253B0006CF35 /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A672B79253B0006CF35 /* UITableViewCell+Identifier.swift */; };
 		59503A6A2B7946D30006CF35 /* RecentHistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */; };
+		59503A6C2B7980B80006CF35 /* AutoCompletionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A6B2B7980B80006CF35 /* AutoCompletionTableViewCell.swift */; };
 		595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */; };
 		596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
@@ -176,6 +177,7 @@
 		59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryHeaderView.swift; sourceTree = "<group>"; };
 		59503A672B79253B0006CF35 /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryTableViewCell.swift; sourceTree = "<group>"; };
+		59503A6B2B7980B80006CF35 /* AutoCompletionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompletionTableViewCell.swift; sourceTree = "<group>"; };
 		595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertMessage.swift; sourceTree = "<group>"; };
 		596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewContents.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 				59503A4D2B751B0B0006CF35 /* SearchViewController.swift */,
 				59503A652B791C930006CF35 /* RecentHistoryHeaderView.swift */,
 				59503A692B7946D30006CF35 /* RecentHistoryTableViewCell.swift */,
+				59503A6B2B7980B80006CF35 /* AutoCompletionTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1199,6 +1202,7 @@
 				59F478BF2B5BEA08002FEF9E /* RequestLocation.swift in Sources */,
 				596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */,
 				59C306B22B50001F00862625 /* FetchStoresRepositoryImpl.swift in Sources */,
+				59503A6C2B7980B80006CF35 /* AutoCompletionTableViewCell.swift in Sources */,
 				5977BE9A2B59AC3300725C90 /* ImageRepository.swift in Sources */,
 				591A887D2B384E600059E40F /* AppDelegate.swift in Sources */,
 				A86D92192B761EC7003B9FEE /* SearchKeywordsRepository.swift in Sources */,

--- a/KCS/KCS/Data/Repository/SearchKeywordRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/SearchKeywordRepositoryImpl.swift
@@ -32,8 +32,7 @@ final class SearchKeywordRepositoryImpl: SearchKeywordsRepository {
             keywords.remove(at: index)
         }
         keywords.insert(recentSearchKeyword, at: 0)
-        // TODO: 최근 검색 최대 개수 수정 필요
-        if keywords.count > 5 {
+        if keywords.count > 30 {
             keywords.removeLast()
         }
         persist(keywords: keywords)

--- a/KCS/KCS/Presentation/Extension/UITableViewCell+Identifier.swift
+++ b/KCS/KCS/Presentation/Extension/UITableViewCell+Identifier.swift
@@ -14,3 +14,11 @@ extension UITableViewCell {
     }
 
 }
+
+extension UITableViewHeaderFooterView {
+    
+    static var identifier: String {
+        return String(describing: self)
+    }
+    
+}

--- a/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
+++ b/KCS/KCS/Presentation/Home/View/MoreStoreButton.swift
@@ -14,7 +14,7 @@ final class MoreStoreButton: UIButton {
             if isEnabled {
                 configuration?.baseForegroundColor = .black
             } else {
-                configuration?.baseForegroundColor = .grayLabel
+                configuration?.baseForegroundColor = .kcsGray1
             }
         }
     }

--- a/KCS/KCS/Presentation/Home/View/SearchBarView.swift
+++ b/KCS/KCS/Presentation/Home/View/SearchBarView.swift
@@ -39,7 +39,7 @@ final class SearchBarView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.image = .searchIcon
-        imageView.tintColor = .grayLabel
+        imageView.tintColor = .kcsGray1
         
         return imageView
     }()
@@ -48,7 +48,7 @@ final class SearchBarView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.image = .xMarkIcon
-        imageView.tintColor = .grayLabel
+        imageView.tintColor = .kcsGray1
         imageView.isHidden = true
         
         return imageView

--- a/KCS/KCS/Presentation/OnBoarding/OnboardingViewController.swift
+++ b/KCS/KCS/Presentation/OnBoarding/OnboardingViewController.swift
@@ -44,7 +44,7 @@ final class OnboardingViewController: UIViewController {
     private lazy var pageControl: UIPageControl = {
         let pageControl = UIPageControl()
         pageControl.translatesAutoresizingMaskIntoConstraints = false
-        pageControl.pageIndicatorTintColor = .swipeBar
+        pageControl.pageIndicatorTintColor = .kcsGray2
         pageControl.currentPageIndicatorTintColor = .primary1
         pageControl.numberOfPages = onboardingViews.count
         pageControl.currentPage = 0

--- a/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
@@ -1,0 +1,70 @@
+//
+//  AutoCompletionTableViewCell.swift
+//  KCS
+//
+//  Created by 조성민 on 2/12/24.
+//
+
+import UIKit
+
+final class AutoCompletionTableViewCell: UITableViewCell {
+    
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = SystemImage.search?.withTintColor(
+            .kcsGray1,
+            renderingMode: .alwaysOriginal
+        )
+
+        return imageView
+    }()
+    
+    private let keywordLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .pretendard(size: 16, weight: .medium)
+        
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        addUIComponents()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setUIContents(keyword: String) {
+        keywordLabel.text = keyword
+    }
+    
+}
+
+private extension AutoCompletionTableViewCell {
+    
+    func addUIComponents() {
+        addSubview(iconImageView)
+        addSubview(keywordLabel)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 16),
+            iconImageView.heightAnchor.constraint(equalToConstant: 16)
+        ])
+        
+        NSLayoutConstraint.activate([
+            keywordLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 10),
+            keywordLabel.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            keywordLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+        ])
+    }
+    
+}

--- a/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
@@ -1,0 +1,94 @@
+//
+//  RecentHistoryHeaderView.swift
+//  KCS
+//
+//  Created by 조성민 on 2/12/24.
+//
+
+import UIKit
+import RxRelay
+import RxSwift
+
+// TODO: 전체삭제 기능 구현
+final class RecentHistoryHeaderView: UITableViewHeaderFooterView {
+    
+    private let disposeBag = DisposeBag()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "최근 검색어"
+        label.font = UIFont.pretendard(size: 17, weight: .semibold)
+        
+        return label
+    }()
+    
+    private lazy var clearAllButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        var attributedTitle = AttributedString("전체삭제")
+        attributedTitle.font = UIFont.pretendard(size: 12, weight: .medium)
+        
+        var config = UIButton.Configuration.plain()
+        config.baseForegroundColor = .placeholderText
+        config.attributedTitle = attributedTitle
+        button.configuration = config
+        
+        return button
+    }()
+    
+    private let divideView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .kcsGray3
+        
+        return view
+    }()
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        addUIComponents()
+        configureConstraints()
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension RecentHistoryHeaderView {
+    
+    func addUIComponents() {
+        addSubview(titleLabel)
+        addSubview(clearAllButton)
+        addSubview(divideView)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            titleLabel.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            clearAllButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            clearAllButton.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            divideView.heightAnchor.constraint(equalToConstant: 1),
+            divideView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            divideView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            divideView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    func setup() {
+        backgroundColor = .white
+    }
+    
+}

--- a/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
@@ -70,20 +70,20 @@ private extension RecentHistoryHeaderView {
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            titleLabel.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            clearAllButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
-            clearAllButton.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+            clearAllButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            clearAllButton.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
         
         NSLayoutConstraint.activate([
             divideView.heightAnchor.constraint(equalToConstant: 1),
-            divideView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            divideView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            divideView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+            divideView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divideView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divideView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
     

--- a/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
@@ -1,0 +1,88 @@
+//
+//  RecentHistoryTableViewCell.swift
+//  KCS
+//
+//  Created by 조성민 on 2/12/24.
+//
+
+import UIKit
+
+// TODO: 최근 검색어 삭제 기능 구현
+final class RecentHistoryTableViewCell: UITableViewCell {
+    
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = SystemImage.search?.withTintColor(
+            .primary3,
+            renderingMode: .alwaysOriginal
+        )
+
+        return imageView
+    }()
+    
+    private let keywordLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .pretendard(size: 16, weight: .medium)
+        
+        return label
+    }()
+    
+    private let removeKeywordButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(SystemImage.remove, for: .normal)
+        button.tintColor = .kcsGray2
+        
+        return button
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        addUIComponents()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setUIContents(keyword: String) {
+        keywordLabel.text = keyword
+    }
+    
+}
+
+private extension RecentHistoryTableViewCell {
+    
+    func addUIComponents() {
+        addSubview(iconImageView)
+        addSubview(keywordLabel)
+        addSubview(removeKeywordButton)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 16),
+            iconImageView.heightAnchor.constraint(equalToConstant: 16)
+        ])
+        
+        NSLayoutConstraint.activate([
+            removeKeywordButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            removeKeywordButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            removeKeywordButton.widthAnchor.constraint(equalToConstant: 14),
+            removeKeywordButton.heightAnchor.constraint(equalToConstant: 14)
+        ])
+        
+        NSLayoutConstraint.activate([
+            keywordLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 10),
+            keywordLabel.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            keywordLabel.trailingAnchor.constraint(equalTo: removeKeywordButton.leadingAnchor, constant: -8)
+        ])
+    }
+    
+}

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -19,7 +19,7 @@ final class SearchViewController: UIViewController {
         
         var config = UIButton.Configuration.plain()
         config.image = .backButton
-        config.baseForegroundColor = .grayLabel
+        config.baseForegroundColor = .kcsGray1
         button.configuration = config
         
         button.rx.tap
@@ -69,7 +69,7 @@ final class SearchViewController: UIViewController {
     private let divideView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .grayLabel
+        view.backgroundColor = .kcsGray3
         
         return view
     }()

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import RxSwift
 import RxRelay
 
+// TODO: 키보드 높이에 따른 레이아웃 수정
 final class SearchViewController: UIViewController {
     
     private let disposeBag = DisposeBag()

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -23,7 +23,6 @@ protocol SearchViewModelInput {
 
 enum SearchViewModelInputCase {
     
-    case viewWillAppear
     case textChanged(text: String)
     case searchButtonTapped(text: String)
     case deleteSearchHistory(index: Int)
@@ -34,5 +33,6 @@ protocol SearchViewModelOutput {
     
     var generateDataOutput: PublishRelay<[String]> { get }
     var recentSearchKeywordsOutput: PublishRelay<[String]> { get }
+    var autoCompleteKeywordsOutput: PublishRelay<[String]> { get }
     
 }

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -18,6 +18,7 @@ final class SearchViewModelImpl: SearchViewModel {
     
     let generateDataOutput = PublishRelay<[String]>()
     let recentSearchKeywordsOutput = PublishRelay<[String]>()
+    let autoCompleteKeywordsOutput = PublishRelay<[String]>()
     
     init(
         fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCase,
@@ -31,8 +32,6 @@ final class SearchViewModelImpl: SearchViewModel {
     
     func action(input: SearchViewModelInputCase) {
         switch input {
-        case .viewWillAppear:
-            viewWillAppear()
         case .textChanged(let text):
             textChanged(text: text)
         case .searchButtonTapped(let text):
@@ -46,23 +45,19 @@ final class SearchViewModelImpl: SearchViewModel {
 
 private extension SearchViewModelImpl {
     
-    func viewWillAppear() {
-        fetchRecentSearchKeywordUseCase.execute()
-            .bind { [weak self] keywords in
-                self?.recentSearchKeywordsOutput.accept(keywords)
-            }
-            .disposed(by: disposeBag)
-    }
-    
     func textChanged(text: String) {
         if text.isEmpty {
-            // TODO: recentHistory usecase 실행(debounce) 후 generateDataOutput.accept([])
+            fetchRecentSearchKeywordUseCase.execute()
+                .bind { [weak self] keywords in
+                    self?.recentSearchKeywordsOutput.accept(keywords)
+                }
+                .disposed(by: disposeBag)
         } else {
-            // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([])
+            // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([]) (자동완성으로 전환)
+            autoCompleteKeywordsOutput.accept([text])
         }
     }
-    
-    // TODO: Cell 선택시 UseCase 내부에서 최근 검색어에 있는지 확인 해야 한다. 
+     
     func searchButtonTapped(text: String) {
         saveRecentSearchKeywordUseCase.execute(
             recentSearchKeyword: text

--- a/KCS/KCS/Presentation/StoreInformation/View/CertificationLabel.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/CertificationLabel.swift
@@ -15,7 +15,7 @@ final class CertificationLabel: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 9, weight: .medium)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         label.text = certificationType.description
         
         return label

--- a/KCS/KCS/Presentation/StoreInformation/View/DetailView.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/DetailView.swift
@@ -25,7 +25,7 @@ final class DetailView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         
         return label
     }()
@@ -43,7 +43,7 @@ final class DetailView: UIView {
     private let divideView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor.divideView
+        view.backgroundColor = UIColor.kcsGray3
         
         return view
     }()
@@ -79,7 +79,7 @@ final class DetailView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 12, weight: .regular)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         
         return label
     }()

--- a/KCS/KCS/Presentation/StoreInformation/View/SummaryView.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/SummaryView.swift
@@ -35,7 +35,7 @@ final class SummaryView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         
         return label
     }()
@@ -53,7 +53,7 @@ final class SummaryView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 13, weight: .regular)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         
         return label
     }()

--- a/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
@@ -28,7 +28,7 @@ final class StoreListViewController: UIViewController {
     private let divideView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor.lightGray
+        view.backgroundColor = UIColor.kcsGray2
         
         return view
     }()

--- a/KCS/KCS/Presentation/StoreList/View/StoreTableViewCell.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreTableViewCell.swift
@@ -34,7 +34,7 @@ final class StoreTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.pretendard(size: 11, weight: .regular)
-        label.textColor = UIColor.grayLabel
+        label.textColor = UIColor.kcsGray1
         
         return label
     }()

--- a/KCS/KCS/Resource/Assets.xcassets/KCSGray1.colorset/Contents.json
+++ b/KCS/KCS/Resource/Assets.xcassets/KCSGray1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.914",
-          "green" : "0.914",
-          "red" : "0.914"
+          "blue" : "0x92",
+          "green" : "0x92",
+          "red" : "0x92"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.914",
-          "green" : "0.914",
-          "red" : "0.914"
+          "blue" : "0x92",
+          "green" : "0x92",
+          "red" : "0x92"
         }
       },
       "idiom" : "universal"
@@ -34,8 +34,5 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
-  },
-  "properties" : {
-    "localizable" : true
   }
 }

--- a/KCS/KCS/Resource/Assets.xcassets/KCSGray2.colorset/Contents.json
+++ b/KCS/KCS/Resource/Assets.xcassets/KCSGray2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.573",
-          "green" : "0.573",
-          "red" : "0.573"
+          "blue" : "0xD9",
+          "green" : "0xD9",
+          "red" : "0xD9"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.573",
-          "green" : "0.573",
-          "red" : "0.573"
+          "blue" : "0xD9",
+          "green" : "0xD9",
+          "red" : "0xD9"
         }
       },
       "idiom" : "universal"
@@ -34,5 +34,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
   }
 }

--- a/KCS/KCS/Resource/Assets.xcassets/KCSGray3.colorset/Contents.json
+++ b/KCS/KCS/Resource/Assets.xcassets/KCSGray3.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.851",
-          "green" : "0.851",
-          "red" : "0.851"
+          "blue" : "0xE9",
+          "green" : "0xE9",
+          "red" : "0xE9"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.780",
-          "green" : "0.780",
-          "red" : "0.780"
+          "blue" : "0xE9",
+          "green" : "0xE9",
+          "red" : "0xE9"
         }
       },
       "idiom" : "universal"
@@ -34,8 +34,5 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
-  },
-  "properties" : {
-    "localizable" : true
   }
 }

--- a/KCS/KCS/Util/SystemImage.swift
+++ b/KCS/KCS/Util/SystemImage.swift
@@ -12,5 +12,7 @@ enum SystemImage {
     static let circle = UIImage(systemName: "circle.fill")
     static let phone = UIImage(systemName: "phone.fill")
     static let refresh = UIImage(systemName: "arrow.clockwise")
+    static let remove = UIImage(systemName: "xmark.circle.fill")
+    static let search = UIImage(systemName: "magnifyingglass")
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #214

## 🚩 Summary

- SearchViewController 레이아웃
- SearchViewController UITableView 2개로 구현

![Simulator Screen Recording - iPhone 15 - 2024-02-12 at 08 07 26](https://github.com/Korea-Certified-Store/iOS/assets/128480641/c8082b9f-1a3f-4614-a1d6-13903419688f)

## 🛠️ Technical Concerns

### UICollectionView vs UITableView & UITableView 2개 사용의 이유

초반에 리스트형태로 되어있는 뷰의 모양으로 UITableView를 사용했습니다. 
하지만 자동완성과 최근 검색어 두가지를 하나의 UITableView로 구현하면서 HeaderView를 사용해야 했습니다.
HeaderView를 Section에 따라 설정하는 것은 UITableView에서는 DiffableDataSource 내부에서는 공식적으로 지원하지 않았습니다.
그래서 UICollectionView로 수정했지만, 하나의 Section이 나올 때 다른 하나의 Section이 사라져야 하는 플로우 자체가 어색하다고 판단하여 두개의 UITableView를 사용했습니다.


## 📋 To Do

- 키보드에 따른 UITableView Constraint 변화
- 최근 검색어 Cell 삭제 연결
- 최근 검색어 전체 삭제 구현