### PR TITLE
검색후 필터 적용 구현

### DIFF
--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -273,8 +273,7 @@ private extension HomeViewModelImpl {
         getSearchStoresUseCase.execute(location: location, keyword: keyword)
             .subscribe(onNext: { [weak self] stores in
                 guard let self = self else { return }
-                dependency.resetFetchCount()
-                dependency.maxFetchCount = 1
+                dependency.fetchCount = stores.count
                 if stores.count == 1 {
                     guard let oneStore = stores.first else { return }
                     searchOneStoreOutput.accept(oneStore)


### PR DESCRIPTION
## ⭐️ Issue Number

- #226 

## 🚩 Summary

- 검색시 필터 버튼이 눌리는 상황에서 가게가 15개씩만 나오는 에러를 수정한다

https://github.com/Korea-Certified-Store/iOS/assets/62226667/59d869e2-1ac6-4594-a233-b40ca5f00272
