### PR TITLE
최근 검색어 cell 별 삭제 구현

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		A8ACB7EF2B5AEBB900540BD1 /* GetStoreInformationUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7EE2B5AEBB800540BD1 /* GetStoreInformationUseCaseImpl.swift */; };
 		A8ACB7F12B5AEBE300540BD1 /* GetStoreInformationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */; };
 		A8AE4B1B2B62A60B00632355 /* OpeningHoursCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */; };
+		A8CD526A2B7B7DFE00917786 /* RecentHistoryTableViewCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CD52692B7B7DFD00917786 /* RecentHistoryTableViewCellDelegate.swift */; };
 		A8E53C252B77DDF3003FCBA2 /* StoreStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */; };
 		A8E53C272B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */; };
 		A8E53C2B2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C2A2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift */; };
@@ -293,6 +294,7 @@
 		A8ACB7EE2B5AEBB800540BD1 /* GetStoreInformationUseCaseImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCaseImpl.swift; sourceTree = "<group>"; };
 		A8ACB7F02B5AEBE300540BD1 /* GetStoreInformationUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCase.swift; sourceTree = "<group>"; };
 		A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursCellView.swift; sourceTree = "<group>"; };
+		A8CD52692B7B7DFD00917786 /* RecentHistoryTableViewCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryTableViewCellDelegate.swift; sourceTree = "<group>"; };
 		A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStorage.swift; sourceTree = "<group>"; };
 		A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoresRepositoryImpl.swift; sourceTree = "<group>"; };
 		A8E53C2A2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSearchStoresRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				59503A512B751FCC0006CF35 /* SearchViewModel.swift */,
+				A8CD52692B7B7DFD00917786 /* RecentHistoryTableViewCellDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1176,6 +1179,7 @@
 				59C306CF2B50399C00862625 /* RequestLocationDTO.swift in Sources */,
 				A83367C32B72714C00E0A844 /* ThirdOnboardingView.swift in Sources */,
 				59503A562B756CCD0006CF35 /* SearchBarView.swift in Sources */,
+				A8CD526A2B7B7DFE00917786 /* RecentHistoryTableViewCellDelegate.swift in Sources */,
 				A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */,
 				59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */,
 				A8ACB7D82B57BE7D00540BD1 /* StoreRepositoryError.swift in Sources */,
@@ -1393,7 +1397,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 7CQAR4CYZX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
@@ -1432,7 +1436,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7CQAR4CYZX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;

--- a/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
@@ -6,8 +6,9 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
-// TODO: 최근 검색어 삭제 기능 구현
 final class RecentHistoryTableViewCell: UITableViewCell {
     
     private let iconImageView: UIImageView = {
@@ -29,18 +30,13 @@ final class RecentHistoryTableViewCell: UITableViewCell {
         return label
     }()
     
-    private let removeKeywordButton: UIButton = {
-        let button = UIButton()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(SystemImage.remove, for: .normal)
-        button.tintColor = .kcsGray2
-        
-        return button
-    }()
+    var disposedBag = DisposeBag()
+    let removeKeywordButton = UIButton()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
+        setButtonConfiguration()
         addUIComponents()
         configureConstraints()
     }
@@ -53,27 +49,38 @@ final class RecentHistoryTableViewCell: UITableViewCell {
         keywordLabel.text = keyword
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposedBag = DisposeBag()
+    }
+    
 }
 
 private extension RecentHistoryTableViewCell {
     
+    func setButtonConfiguration() {
+        removeKeywordButton.translatesAutoresizingMaskIntoConstraints = false
+        removeKeywordButton.setImage(SystemImage.remove, for: .normal)
+        removeKeywordButton.tintColor = .kcsGray2
+    }
+    
     func addUIComponents() {
-        addSubview(iconImageView)
-        addSubview(keywordLabel)
-        addSubview(removeKeywordButton)
+        contentView.addSubview(iconImageView)
+        contentView.addSubview(keywordLabel)
+        contentView.addSubview(removeKeywordButton)
     }
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             iconImageView.widthAnchor.constraint(equalToConstant: 16),
             iconImageView.heightAnchor.constraint(equalToConstant: 16)
         ])
         
         NSLayoutConstraint.activate([
-            removeKeywordButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            removeKeywordButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            removeKeywordButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            removeKeywordButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             removeKeywordButton.widthAnchor.constraint(equalToConstant: 14),
             removeKeywordButton.heightAnchor.constraint(equalToConstant: 14)
         ])
@@ -85,4 +92,8 @@ private extension RecentHistoryTableViewCell {
         ])
     }
     
+}
+
+extension Reactive where Base: RecentHistoryTableViewCell {
+    var removeKeywordButtonTapped: ControlEvent<Void> { base.removeKeywordButton.rx.tap }
 }

--- a/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryTableViewCell.swift
@@ -30,13 +30,29 @@ final class RecentHistoryTableViewCell: UITableViewCell {
         return label
     }()
     
-    var disposedBag = DisposeBag()
-    let removeKeywordButton = UIButton()
+    private lazy var removeKeywordButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(SystemImage.remove, for: .normal)
+        button.tintColor = .kcsGray2
+        button.rx.tap
+            .bind { [weak self] in
+                guard let self = self,
+                      let indexPath = indexPath else { return }
+                delegate?.removeKeywordButtonTapped(index: indexPath.row)
+            }
+            .disposed(by: disposedBag)
+        
+        return button
+    }()
+    
+    private let disposedBag = DisposeBag()
+    private var indexPath: IndexPath?
+    var delegate: RecentHistoryTableViewCellDelegate?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        setButtonConfiguration()
         addUIComponents()
         configureConstraints()
     }
@@ -49,20 +65,13 @@ final class RecentHistoryTableViewCell: UITableViewCell {
         keywordLabel.text = keyword
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        disposedBag = DisposeBag()
+    func setIndexPath(indexPath: IndexPath) {
+        self.indexPath = indexPath
     }
     
 }
 
 private extension RecentHistoryTableViewCell {
-    
-    func setButtonConfiguration() {
-        removeKeywordButton.translatesAutoresizingMaskIntoConstraints = false
-        removeKeywordButton.setImage(SystemImage.remove, for: .normal)
-        removeKeywordButton.tintColor = .kcsGray2
-    }
     
     func addUIComponents() {
         contentView.addSubview(iconImageView)
@@ -92,8 +101,4 @@ private extension RecentHistoryTableViewCell {
         ])
     }
     
-}
-
-extension Reactive where Base: RecentHistoryTableViewCell {
-    var removeKeywordButtonTapped: ControlEvent<Void> { base.removeKeywordButton.rx.tap }
 }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -97,12 +97,9 @@ final class SearchViewController: UIViewController {
                     withIdentifier: RecentHistoryTableViewCell.identifier
                 ) as? RecentHistoryTableViewCell else { return RecentHistoryTableViewCell() }
                 cell.setUIContents(keyword: keyword)
+                cell.setIndexPath(indexPath: indexPath)
                 cell.selectionStyle = .none
-                cell.rx.removeKeywordButtonTapped
-                    .bind { [weak self] in
-                        self?.viewModel.action(input: .deleteSearchHistory(index: indexPath.row))
-                    }
-                    .disposed(by: cell.disposedBag)
+                cell.delegate = self
                 
                 return cell
             }
@@ -283,6 +280,14 @@ private extension SearchViewController {
         viewModel.action(input: .searchButtonTapped(text: text))
     }
 
+}
+
+extension SearchViewController: RecentHistoryTableViewCellDelegate {
+    
+    func removeKeywordButtonTapped(index: Int) {
+        viewModel.action(input: .deleteSearchHistory(index: index))
+    }
+    
 }
 
 extension SearchViewController: UITableViewDelegate {

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -92,13 +92,17 @@ final class SearchViewController: UIViewController {
     private lazy var recentHistoryDataSource: UITableViewDiffableDataSource<RecentHistorySection, String> = {
         let dataSource = UITableViewDiffableDataSource<RecentHistorySection, String>(
             tableView: recentHistoryTableView,
-            cellProvider: { (tableView, _, keyword) in
+            cellProvider: { (tableView, indexPath, keyword) in
                 guard let cell = tableView.dequeueReusableCell(
                     withIdentifier: RecentHistoryTableViewCell.identifier
                 ) as? RecentHistoryTableViewCell else { return RecentHistoryTableViewCell() }
                 cell.setUIContents(keyword: keyword)
                 cell.selectionStyle = .none
-                // TODO: cell 삭제 바인딩
+                cell.rx.removeKeywordButtonTapped
+                    .bind { [weak self] in
+                        self?.viewModel.action(input: .deleteSearchHistory(index: indexPath.row))
+                    }
+                    .disposed(by: cell.disposedBag)
                 
                 return cell
             }
@@ -263,7 +267,7 @@ private extension SearchViewController {
         var snapshot = NSDiffableDataSourceSnapshot<RecentHistorySection, String>()
         snapshot.appendSections([.recentHistory])
         snapshot.appendItems(data)
-        recentHistoryDataSource.apply(snapshot, animatingDifferences: false)
+        recentHistoryDataSource.applySnapshotUsingReloadData(snapshot)
     }
     
     func generateAutoCompletionData(data: [String]) {

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -260,6 +260,7 @@ private extension SearchViewController {
 
 private extension SearchViewController {
     
+    // TODO: Reload Data 수정 필요
     func generateRecentHistoryData(data: [String]) {
         var snapshot = NSDiffableDataSourceSnapshot<RecentHistorySection, String>()
         snapshot.appendSections([.recentHistory])

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/RecentHistoryTableViewCellDelegate.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/RecentHistoryTableViewCellDelegate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol RecentHistoryTableViewCellDelegate {
+protocol RecentHistoryTableViewCellDelegate: AnyObject {
     
     func removeKeywordButtonTapped(index: Int)
     

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/RecentHistoryTableViewCellDelegate.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/RecentHistoryTableViewCellDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  RecentHistoryTableViewCellDelegate.swift
+//  KCS
+//
+//  Created by 김영현 on 2/13/24.
+//
+
+import Foundation
+
+protocol RecentHistoryTableViewCellDelegate {
+    
+    func removeKeywordButtonTapped(index: Int)
+    
+}

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -47,11 +47,7 @@ private extension SearchViewModelImpl {
     
     func textChanged(text: String) {
         if text.isEmpty {
-            fetchRecentSearchKeywordUseCase.execute()
-                .bind { [weak self] keywords in
-                    self?.recentSearchKeywordsOutput.accept(keywords)
-                }
-                .disposed(by: disposeBag)
+            emitRecentHistory()
         } else {
             // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([]) (자동완성으로 전환)
             autoCompleteKeywordsOutput.accept([text])
@@ -66,6 +62,15 @@ private extension SearchViewModelImpl {
     
     func deleteSearchHistory(index: Int) {
         deleteRecentSearchKeywordUseCase.execute(index: index)
+        emitRecentHistory()
+    }
+    
+    func emitRecentHistory() {
+        fetchRecentSearchKeywordUseCase.execute()
+            .bind { [weak self] keywords in
+                self?.recentSearchKeywordsOutput.accept(keywords)
+            }
+            .disposed(by: disposeBag)
     }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #228 

## 🚩 Summary

- 최근 검색어 cell의 삭제 기능 구현

![Simulator Screen Recording - iPhone 15 - 2024-02-13 at 05 10 03](https://github.com/Korea-Certified-Store/iOS/assets/62226667/ef8c7b76-93bd-4c8b-8412-de0ad4e41844)

## 🛠️ Technical Concerns

### 의존성 주입

처음 기능 구현을 할 땐, custom cell 마다 initialize를 custom해줄 수 없기 때문에 의존성을 주입받기 어렵다고 생각되어 클래스 밖에서 cell의 button 자체에 접근 가능하게 구현하였다.
하지만 usecase에서 repository에 접근하기 위해 protocol을 사용하여 의존성을 주입시켜주는 것과 동일한 방법으로 delegate를 이용하여 구현하면 의존성을 밖에서 주입받을 수 있었다.

```swift
protocol RecentHistoryTableViewCellDelegate: AnyObject {
    func removeKeywordButtonTapped(index: Int)
}
```

이때, 위임 프로토콜은 추후 약한 참조될 수 있게 하기 위해 클래스 전용임을 나타내 주어야 한다.
따라서 해당 프로토콜에 AnyObject를 채택해주었다.

### applySnapshotUsingReloadData

현재 UserDefaults를 삭제하는 로직은 indexPath 값을 통해 배열의 위치를 찾아들어가 삭제하는 방식을 채택하고있다.
보통은 dataSource를 update해줄때 `apply`를 사용하는데, `apply`를 통해 DataSource를 바꿔주면 cell의 indexPath값은 변하지 않는 이슈가 발생하였다. 이렇게 되면 제대로된 UserDefaults 배열의 위치로 찾아들어가지 못하게된다.
따라서 `applySnapshotUsingReloadData`를 사용하여 dataSource가 바뀌는 즉시 indexPath 또한 업데이트 해주는 방식으로 코드를 진행하였다.

