### PR TITLE
StoreListViewController 상단 title 수정

### DIFF
--- a/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
+++ b/KCS/KCS/Presentation/Extension/UISheetPresentationController+Detent.swift
@@ -29,7 +29,7 @@ extension UISheetPresentationController.Detent {
         return 616 - 21
     }    
     static let smallStoreListViewDetent = custom(identifier: .smallStoreListViewDetentIdentifier) { _ in
-        return 40
+        return 55
     }
     static let largeStoreListViewDetent = large()
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -345,6 +345,9 @@ private extension HomeViewController {
                 storeListViewController.updateList(stores: stores)
                 if stores.isEmpty {
                     showToast(message: "가게가 없습니다.")
+                    storeListViewController.updateCountLabel(text: "검색 결과가 존재하지 않습니다")
+                } else {
+                    storeListViewController.updateCountLabel(text: "총 \(stores.count)개의 가게가 있습니다")
                 }
             }
             .disposed(by: disposeBag)
@@ -817,6 +820,9 @@ private extension HomeViewController {
         storeListViewController.updateList(stores: stores)
         if stores.isEmpty {
             showToast(message: "가게가 없습니다.")
+            storeListViewController.updateCountLabel(text: "검색 결과가 존재하지 않습니다")
+        } else {
+            storeListViewController.updateCountLabel(text: "총 \(stores.count)개의 가게가 있습니다")
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -119,7 +119,7 @@ final class HomeViewController: UIViewController {
         map.showIndoorLevelPicker = false
         map.showLocationButton = false
         map.mapView.logoAlign = .rightBottom
-        map.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: 55, right: 0)
+        map.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: 69, right: 0)
         map.mapView.touchDelegate = self
         map.mapView.addCameraDelegate(delegate: self)
         
@@ -208,15 +208,15 @@ final class HomeViewController: UIViewController {
     }()
     
     private lazy var refreshButtonBottomConstraint = refreshButton.bottomAnchor.constraint(
-        equalTo: mapView.bottomAnchor, constant: -90
+        equalTo: mapView.bottomAnchor, constant: -104
     )
     
     private lazy var moreStoreButtonBottomConstraint = moreStoreButton.bottomAnchor.constraint(
-        equalTo: mapView.bottomAnchor, constant: -90
+        equalTo: mapView.bottomAnchor, constant: -104
     )
     
     private lazy var locationButtonBottomConstraint = locationButton.bottomAnchor.constraint(
-        equalTo: mapView.bottomAnchor, constant: -90
+        equalTo: mapView.bottomAnchor, constant: -104
     )
     
     private lazy var searchBarViewLeadingConstraint = searchBarView.leadingAnchor.constraint(
@@ -692,10 +692,10 @@ private extension HomeViewController {
                 sheet.prefersGrabberVisible = true
                 sheet.preferredCornerRadius = 15
             }
-            refreshButtonBottomConstraint.constant = -90
-            locationButtonBottomConstraint.constant = -90
-            moreStoreButtonBottomConstraint.constant = -90
-            mapView.mapView.logoMargin.bottom = 55
+            refreshButtonBottomConstraint.constant = -104
+            locationButtonBottomConstraint.constant = -104
+            moreStoreButtonBottomConstraint.constant = -104
+            mapView.mapView.logoMargin.bottom = 69
             UIView.animate(withDuration: 0.5) {
                 self.view.layoutIfNeeded()
             }

--- a/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
+++ b/KCS/KCS/Presentation/StoreList/View/StoreListViewController.swift
@@ -23,7 +23,16 @@ final class StoreListViewController: UIViewController {
         label.textColor = .black
         
         return label
-    }()    
+    }()
+    
+    private let storeCountLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.pretendard(size: 14, weight: .regular)
+        label.textColor = .kcsGray1
+        
+        return label
+    }()
     
     private let divideView: UIView = {
         let view = UIView()
@@ -90,6 +99,10 @@ final class StoreListViewController: UIViewController {
         viewModel.action(input: .updateList(stores: stores))
     }
     
+    func updateCountLabel(text: String) {
+        storeCountLabel.text = text
+    }
+    
     func scrollToPreviousCell(indexPath: IndexPath) {
         storeTableView.scrollToRow(at: indexPath, at: .top, animated: false)
     }
@@ -107,17 +120,23 @@ private extension StoreListViewController {
     func addUIComponents() {
         view.addSubview(storeTableView)
         view.addSubview(titleLabel)
+        view.addSubview(storeCountLabel)
         view.addSubview(divideView)
     }
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 27),
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 25),
             titleLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            divideView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 27),
+            storeCountLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            storeCountLabel.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            divideView.topAnchor.constraint(equalTo: storeCountLabel.bottomAnchor, constant: 23),
             divideView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             divideView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             divideView.heightAnchor.constraint(equalToConstant: 0.5)


### PR DESCRIPTION
## ⭐️ Issue Number

- #230 

## 🚩 Summary

- StoreListViewController의 상단 Title에 현재 검색된 가게 개수를 표시하는 label을 추가한다
- 화면 하단 버튼들의 Constaraints를 수정한다

|![Simulator Screen Recording - iPhone 15 - 2024-02-13 at 20 54 17](https://github.com/Korea-Certified-Store/iOS/assets/62226667/1f5ab01e-54d9-4627-9c01-f2a0a441bd43)|![Simulator Screen Recording - iPhone 15 - 2024-02-13 at 20 54 34](https://github.com/Korea-Certified-Store/iOS/assets/62226667/77e2a00b-b3b7-4319-b166-3197056dfda0)|
|:--:|:--:|
|범위 내 가게가 있는 경우|범위 내 가게가 없는 경우|

## 📋 To Do

- 범위 내 가게가 없는 경우 StoreListView의 tableView 대신 다른 가게가 없다는 View를 보여줘야 한다
