### PR TITLE
Keyboard 높이에 맞게 UITableView Constraints

### DIFF
--- a/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
+++ b/KCS/KCS/Presentation/Search/View/RecentHistoryHeaderView.swift
@@ -63,32 +63,32 @@ final class RecentHistoryHeaderView: UITableViewHeaderFooterView {
 private extension RecentHistoryHeaderView {
     
     func addUIComponents() {
-        addSubview(titleLabel)
-        addSubview(clearAllButton)
-        addSubview(divideView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(clearAllButton)
+        contentView.addSubview(divideView)
     }
     
     func configureConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            clearAllButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-            clearAllButton.centerYAnchor.constraint(equalTo: centerYAnchor)
+            clearAllButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            clearAllButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
         
         NSLayoutConstraint.activate([
             divideView.heightAnchor.constraint(equalToConstant: 1),
-            divideView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            divideView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            divideView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            divideView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            divideView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            divideView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
     
     func setup() {
-        backgroundColor = .white
+        contentView.backgroundColor = .white
     }
     
 }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -8,8 +8,8 @@
 import UIKit
 import RxSwift
 import RxRelay
+import RxKeyboard
 
-// TODO: 키보드 높이에 따른 레이아웃 수정
 final class SearchViewController: UIViewController {
     
     private let disposeBag = DisposeBag()
@@ -146,6 +146,15 @@ final class SearchViewController: UIViewController {
         return view
     }()
     
+    private lazy var tableViewBottomConstraint = [
+        autoCompletionTableView.bottomAnchor.constraint(
+            equalTo: view.bottomAnchor
+        ),
+        recentHistoryTableView.bottomAnchor.constraint(
+            equalTo: view.bottomAnchor
+        )
+    ]
+    
     private let searchObserver: PublishRelay<String>
     private let viewModel: SearchViewModel
     
@@ -226,16 +235,16 @@ private extension SearchViewController {
         NSLayoutConstraint.activate([
             recentHistoryTableView.topAnchor.constraint(equalTo: divideView.bottomAnchor),
             recentHistoryTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            recentHistoryTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            recentHistoryTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            recentHistoryTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
         
         NSLayoutConstraint.activate([
             autoCompletionTableView.topAnchor.constraint(equalTo: divideView.bottomAnchor),
             autoCompletionTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            autoCompletionTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            autoCompletionTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            autoCompletionTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+        
+        NSLayoutConstraint.activate(tableViewBottomConstraint)
     }
     
     func bind() {
@@ -252,6 +261,13 @@ private extension SearchViewController {
                 self?.recentHistoryTableView.isHidden = true
                 self?.autoCompletionTableView.isHidden = false
                 self?.generateAutoCompletionData(data: keywords)
+            }
+            .disposed(by: disposeBag)
+        
+        RxKeyboard.instance.visibleHeight
+            .asObservable()
+            .bind { [weak self] keyboardHeight in
+                self?.tableViewBottomConstraint.forEach({ $0.constant = -keyboardHeight })
             }
             .disposed(by: disposeBag)
     }

--- a/KCS/Podfile
+++ b/KCS/Podfile
@@ -16,6 +16,7 @@ target 'KCS' do
   pod 'NMapsMap'
   pod 'Firebase/Analytics'
   pod 'Firebase/Crashlytics'
+  pod 'RxKeyboard'
 
 post_install do |installer|
     installer.pods_project.targets.each do |target|

--- a/KCS/Podfile.lock
+++ b/KCS/Podfile.lock
@@ -119,6 +119,9 @@ PODS:
   - RxGesture (4.0.4):
     - RxCocoa (~> 6.0)
     - RxSwift (~> 6.0)
+  - RxKeyboard (2.0.0):
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - RxRelay (6.6.0):
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
@@ -134,6 +137,7 @@ DEPENDENCIES:
   - RxBlocking
   - RxCocoa (= 6.6.0)
   - RxGesture
+  - RxKeyboard
   - RxSwift (= 6.6.0)
   - RxTest
   - SwiftLint
@@ -160,6 +164,7 @@ SPEC REPOS:
     - RxBlocking
     - RxCocoa
     - RxGesture
+    - RxKeyboard
     - RxRelay
     - RxSwift
     - RxTest
@@ -186,11 +191,12 @@ SPEC CHECKSUMS:
   RxBlocking: fbd1f8501443024f686e556f36dac79b0d5f4d7c
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
   RxGesture: f3efb47ed2d26a8082f7b660d4a59970e275a7f8
+  RxKeyboard: 4f5863f43b4ff0cbb2a20b94688d6b80c8a43c14
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   RxTest: a23f26bb53a5e146a0a69db4f0fa0b69001ce7f4
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: a5566a18764ef703abc0265b00efa39f0938cc7c
+PODFILE CHECKSUM: 64333e89ec52ee57b76d093be0a982458f7eb236
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
## ⭐️ Issue Number

- #241

## 🚩 Summary

- RxKeyboard 추가
- KeyBoard의 위치에 따라 UITableView Constraints Bottom Constraint 바인딩
- HeaderView view.addSubview -> contentView.addSubview로 수정

## 🛠️ Technical Concerns

### RxKeyboard의 사용

NotificationCenter에서 공식적으로 지원하는 KeyboardWillShow와 KeyBoardWillHide를 사용할 수도 있었다.
하지만 Rx를 사용하기로 했기 때문에 NotificationCenter를 사용하는 것을 최대한 지양했다.
그래서 RxKeyboard를 도입하여 Keyboard의 높이 변화를 쉽게 바인딩할 수 있었다.
