### PR TITLE
지도 마커가 나오는 범위 설정

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -695,10 +695,10 @@ private extension HomeViewController {
     }
     
     func makeRequestLocation(projection: NMFProjection) -> RequestLocation {
-        let northWestPoint = projection.latlng(from: CGPoint(x: 0, y: 0))
-        let southWestPoint = projection.latlng(from: CGPoint(x: 0, y: view.frame.height))
-        let southEastPoint = projection.latlng(from: CGPoint(x: view.frame.width, y: view.frame.height))
-        let northEastPoint = projection.latlng(from: CGPoint(x: view.frame.width, y: 0))
+        let northWestPoint = projection.latlng(from: CGPoint(x: 0 + 10, y: filterButtonStackView.frame.maxY + 10))
+        let southWestPoint = projection.latlng(from: CGPoint(x: 0 + 10, y: locationButton.frame.minY - 10))
+        let southEastPoint = projection.latlng(from: CGPoint(x: view.frame.width - 10, y: locationButton.frame.minY - 10))
+        let northEastPoint = projection.latlng(from: CGPoint(x: view.frame.width - 10, y: filterButtonStackView.frame.maxY))
         
         return RequestLocation(
             northWest: Location(


### PR DESCRIPTION
## ⭐️ Issue Number

- #243

## 🚩 Summary

- 검색 좌표 재설정

## 🛠️ Technical Concerns

### 사용자가 실제로 사용하는 뷰의 범위

|<img width="408" alt="스크린샷 2024-02-14 오후 8 28 57" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/1a55d163-e26c-4476-99c0-4880447ae236">|
| - |

사용자가 실제로 접근성이 있는 뷰의 범위는 위의 스크린샷의 사각형 내부다.
그래서 검색의 범위를 화면 전체에서 해당 사각형의 내부로 수정했다.
