### PR TITLE
빈 값 검색 방지 구현

### DIFF
--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -355,9 +355,13 @@ extension SearchViewController: UITableViewDelegate {
 extension SearchViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let text = textField.text {
-            search(text: text)
-            return true
+        if let text = textField.text?.trimmingCharacters(in: .whitespaces) {
+            if !text.isEmpty {
+                search(text: text)
+                return true
+            } else {
+                return false
+            }
         } else {
             return false
         }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -35,6 +35,7 @@ final class SearchViewController: UIViewController {
     private lazy var searchBarView: SearchBarView = {
         let view = SearchBarView()
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.searchTextField.enablesReturnKeyAutomatically = true
         view.searchTextField.delegate = self
         
         Observable.merge(
@@ -264,6 +265,12 @@ private extension SearchViewController {
             }
             .disposed(by: disposeBag)
         
+        viewModel.searchOutput
+            .bind { [weak self] keyword in
+                self?.search(text: keyword)
+            }
+            .disposed(by: disposeBag)
+        
         RxKeyboard.instance.visibleHeight
             .asObservable()
             .bind { [weak self] keyboardHeight in
@@ -355,16 +362,10 @@ extension SearchViewController: UITableViewDelegate {
 extension SearchViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let text = textField.text?.trimmingCharacters(in: .whitespaces) {
-            if !text.isEmpty {
-                search(text: text)
-                return true
-            } else {
-                return false
-            }
-        } else {
-            return false
+        if let text = textField.text {
+            viewModel.action(input: .returnKeyTapped(text: text))
         }
+        return false
     }
     
 }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -52,6 +52,7 @@ final class SearchViewController: UIViewController {
             .when(.ended)
             .subscribe(onNext: { [weak self] _ in
                 view.searchTextField.text = ""
+                view.searchTextField.becomeFirstResponder()
             })
             .disposed(by: disposeBag)
         
@@ -86,6 +87,12 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
+        tableView.rx.tapGesture()
+            .when(.ended)
+            .bind { [weak self] _ in
+                self?.searchBarView.searchTextField.resignFirstResponder()
+            }
+            .disposed(by: disposeBag)
         
         return tableView
     }()
@@ -118,7 +125,13 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
-        
+        tableView.rx.tapGesture()
+            .when(.ended)
+            .bind { [weak self] _ in
+                self?.searchBarView.searchTextField.resignFirstResponder()
+            }
+            .disposed(by: disposeBag)
+
         return tableView
     }()
     

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -28,13 +28,14 @@ enum SearchViewModelInputCase {
     case searchButtonTapped(text: String)
     case deleteSearchHistory(index: Int)
     case deleteAllHistory
+    case returnKeyTapped(text: String)
     
 }
 
 protocol SearchViewModelOutput {
     
-    var generateDataOutput: PublishRelay<[String]> { get }
     var recentSearchKeywordsOutput: PublishRelay<[String]> { get }
     var autoCompleteKeywordsOutput: PublishRelay<[String]> { get }
+    var searchOutput: PublishRelay<String> { get }
     
 }

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -17,9 +17,9 @@ final class SearchViewModelImpl: SearchViewModel {
     var deleteRecentSearchKeywordUseCase: DeleteRecentSearchKeywordUseCase
     var deleteAllHistoryUseCase: DeleteAllHistoryUseCase
     
-    let generateDataOutput = PublishRelay<[String]>()
     let recentSearchKeywordsOutput = PublishRelay<[String]>()
     let autoCompleteKeywordsOutput = PublishRelay<[String]>()
+    let searchOutput = PublishRelay<String>()
     
     init(
         fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCase,
@@ -43,6 +43,8 @@ final class SearchViewModelImpl: SearchViewModel {
             deleteSearchHistory(index: index)
         case .deleteAllHistory:
             deleteAllHistory()
+        case .returnKeyTapped(let text):
+            returnKeyTapped(text: text)
         }
     }
     
@@ -81,6 +83,12 @@ private extension SearchViewModelImpl {
                 self?.recentSearchKeywordsOutput.accept(keywords)
             }
             .disposed(by: disposeBag)
+    }
+    
+    func returnKeyTapped(text: String) {
+        if !text.trimmingCharacters(in: .whitespaces).isEmpty {
+            searchOutput.accept(text)
+        }
     }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #246 

## 🚩 Summary

- 빈 값(스페이스만)일 경우 검색이 불가능 하도록 막는다
- 키보드 밖을 터치하는 경우 키보드가 아래로 내려가도록 한다

|![Simulator Screen Recording - iPhone 15 - 2024-02-14 at 21 08 32](https://github.com/Korea-Certified-Store/iOS/assets/62226667/d2f5cfbd-6890-4bdd-95bf-5bd204cc8f39)|![Simulator Screen Recording - iPhone 15 - 2024-02-14 at 21 54 58](https://github.com/Korea-Certified-Store/iOS/assets/62226667/3ee172d8-a8a1-4e86-83be-95438721468b)|
|:--:|:--:|
|빈 값 검색 방지|키보드 내리기|

## 🛠️ Technical Concerns

### trimmingCharacters

문자열을 검색할 때 앞 뒤 공백만 삭제하고 중간에 존재하는 공백은 그대로인 상태로 검색을 해야했다.
`.trimmingCharacters(in: .whitespaces)`을 사용하면 앞 뒤 공백만 없앤 문자열을 받을 수 있었다.
