### PR TITLE
4.0 업데이트 이전 변경사항 적용

### DIFF
--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -332,7 +332,6 @@ private extension HomeViewController {
                 status: locationManager.authorizationStatus
             )
         )
-        navigationController?.isNavigationBarHidden = true
     }
     
     func bind() {
@@ -428,12 +427,6 @@ private extension HomeViewController {
             }
             .disposed(by: disposeBag)
         
-        viewModel.locationButtonImageNameOutput
-            .bind { [weak self] imageName in
-                self?.locationButton.setImage(UIImage(named: imageName), for: .normal)
-            }
-            .disposed(by: disposeBag)
-        
         viewModel.requestLocationAuthorizationOutput
             .bind { [weak self] in
                 self?.presentLocationAlert()
@@ -512,6 +505,7 @@ private extension HomeViewController {
                 cameraUpdate.animation = .none
                 mapView.mapView.moveCamera(cameraUpdate)
                 mapView.mapView.positionMode = .direction
+                locationButton.setImage(UIImage.locationButtonNormal, for: .normal)
                 refresh()
             }
             .disposed(by: disposeBag)
@@ -603,6 +597,7 @@ private extension HomeViewController {
                     mapView.mapView.moveCamera(cameraUpdate)
                 }
                 mapView.mapView.positionMode = .normal
+                locationButton.setImage(UIImage.locationButtonNone, for: .normal)
             }
             .disposed(by: disposeBag)
         
@@ -621,6 +616,7 @@ private extension HomeViewController {
                 cameraUpdate.animationDuration = 0.5
                 mapView.mapView.moveCamera(cameraUpdate)
                 mapView.mapView.positionMode = .normal
+                locationButton.setImage(UIImage.locationButtonNone, for: .normal)
                 
                 guard let marker = markers.first(where: { $0.tag == store.id}) else { return }
                 if let clickedMarker = clickedMarker {
@@ -913,16 +909,6 @@ extension HomeViewController: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
         if reason == NMFMapChangedByGesture {
             locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-        }
-    }
-    
-    func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
-        if reason == NMFMapChangedByDeveloper {
-            viewModel.action(input:
-                    .checkLocationAuthorizationWhenCameraDidChange(
-                        status: locationManager.authorizationStatus
-                    )
-            )
         }
     }
     

--- a/KCS/KCS/Presentation/Home/View/SearchBarView.swift
+++ b/KCS/KCS/Presentation/Home/View/SearchBarView.swift
@@ -32,6 +32,20 @@ final class SearchBarView: UIView {
         }
         .disposed(by: disposeBag)
         
+        let keyboardToolbar = UIToolbar()
+        let flexBarButton = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let doneBarButton = UIBarButtonItem(barButtonSystemItem: .close, target: nil, action: nil)
+        doneBarButton.rx.tap
+            .bind { _ in
+                textField.resignFirstResponder()
+            }
+            .disposed(by: disposeBag)
+        keyboardToolbar.items = [flexBarButton, doneBarButton]
+        keyboardToolbar.sizeToFit()
+        keyboardToolbar.tintColor = UIColor.systemGray
+        
+        textField.inputAccessoryView = keyboardToolbar
+        
         return textField
     }()
     

--- a/KCS/KCS/Presentation/Home/View/SearchBarView.swift
+++ b/KCS/KCS/Presentation/Home/View/SearchBarView.swift
@@ -32,20 +32,6 @@ final class SearchBarView: UIView {
         }
         .disposed(by: disposeBag)
         
-        let keyboardToolbar = UIToolbar()
-        let flexBarButton = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneBarButton = UIBarButtonItem(barButtonSystemItem: .close, target: nil, action: nil)
-        doneBarButton.rx.tap
-            .bind { _ in
-                textField.resignFirstResponder()
-            }
-            .disposed(by: disposeBag)
-        keyboardToolbar.items = [flexBarButton, doneBarButton]
-        keyboardToolbar.sizeToFit()
-        keyboardToolbar.tintColor = UIColor.systemGray
-        
-        textField.inputAccessoryView = keyboardToolbar
-        
         return textField
     }()
     

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -20,7 +20,6 @@ final class HomeViewModelImpl: HomeViewModel {
     let getStoreInformationOutput = PublishRelay<Store>()
     let refreshDoneOutput = PublishRelay<Bool>()
     let locationButtonOutput = PublishRelay<NMFMyPositionMode>()
-    let locationButtonImageNameOutput = PublishRelay<String>()
     let setMarkerOutput = PublishRelay<MarkerContents>()
     let locationAuthorizationStatusDeniedOutput = PublishRelay<Void>()
     let locationStatusNotDeterminedOutput = PublishRelay<Void>()
@@ -69,8 +68,6 @@ final class HomeViewModelImpl: HomeViewModel {
             setMarker(store: store, certificationType: certificationType)
         case .checkLocationAuthorization(let status):
             checkLocationAuthorization(status: status)
-        case .checkLocationAuthorizationWhenCameraDidChange(let status):
-            checkLocationAuthorizationWhenCameraDidChange(status: status)
         case .search(let location, let keyword):
             search(location: location, keyword: keyword)
         case .resetFilters:
@@ -255,17 +252,6 @@ private extension HomeViewModelImpl {
             locationStatusAuthorizedWhenInUseOutput.accept(())
         default:
             locationAuthorizationStatusDeniedOutput.accept(())
-        }
-    }
-    
-    func checkLocationAuthorizationWhenCameraDidChange(status: CLAuthorizationStatus) {
-        switch status {
-        case .denied, .restricted, .notDetermined:
-            locationButtonImageNameOutput.accept("LocationButtonNone")
-        case .authorizedWhenInUse:
-            locationButtonImageNameOutput.accept("LocationButtonNormal")
-        default:
-            break
         }
     }
     

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -37,7 +37,6 @@ enum HomeViewModelInputCase {
     case dimViewTapGestureEnded
     case setMarker(store: Store, certificationType: CertificationType)
     case checkLocationAuthorization(status: CLAuthorizationStatus)
-    case checkLocationAuthorizationWhenCameraDidChange(status: CLAuthorizationStatus)
     case search(location: Location, keyword: String)
     case resetFilters
     case compareCameraPosition(
@@ -61,7 +60,6 @@ protocol HomeViewModelOutput {
     var refreshDoneOutput: PublishRelay<Bool> { get }
     var filteredStoresOutput: PublishRelay<[FilteredStores]> { get }
     var locationButtonOutput: PublishRelay<NMFMyPositionMode> { get }
-    var locationButtonImageNameOutput: PublishRelay<String> { get }
     var setMarkerOutput: PublishRelay<MarkerContents> { get }
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }
     var locationStatusNotDeterminedOutput: PublishRelay<Void> { get }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -87,12 +87,6 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
-        tableView.rx.tapGesture()
-            .when(.ended)
-            .bind { [weak self] _ in
-                self?.searchBarView.searchTextField.resignFirstResponder()
-            }
-            .disposed(by: disposeBag)
         
         return tableView
     }()
@@ -125,12 +119,6 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
-        tableView.rx.tapGesture()
-            .when(.ended)
-            .bind { [weak self] _ in
-                self?.searchBarView.searchTextField.resignFirstResponder()
-            }
-            .disposed(by: disposeBag)
 
         return tableView
     }()
@@ -332,7 +320,7 @@ extension SearchViewController: RecentHistoryTableViewCellDelegate, RecentHistor
                 message: "최근 검색어를 모두 삭제하시겠습니까?",
                 preferredStyle: .alert
             )
-            let delete = UIAlertAction(title: "삭제", style: .default) { [weak self] _ in
+            let delete = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
                 self?.viewModel.action(input: .deleteAllHistory)
             }
             let cancel = UIAlertAction(title: "취소", style: .cancel)

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -87,6 +87,7 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
+        tableView.keyboardDismissMode = .onDrag
         tableView.showsVerticalScrollIndicator = false
         
         return tableView
@@ -120,6 +121,7 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
+        tableView.keyboardDismissMode = .onDrag
         tableView.showsVerticalScrollIndicator = false
 
         return tableView

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -87,6 +87,7 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
+        tableView.showsVerticalScrollIndicator = false
         
         return tableView
     }()
@@ -119,6 +120,7 @@ final class SearchViewController: UIViewController {
         tableView.sectionHeaderTopPadding = 0
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.separatorInset = .zero
+        tableView.showsVerticalScrollIndicator = false
 
         return tableView
     }()


### PR DESCRIPTION
## ⭐️ Issue Number

- #249 
## 🚩 Summary

- Alert의 삭제 버튼 style을 `.destructive`로 변경한다
- Drag로 키보드 Dismiss
- 검색시 LocationButton의 이미지를 수정한다
- TableView 스크롤시 보이는 Scroll indicator를 삭제한다

|![Simulator Screen Recording - iPhone 15 - 2024-02-15 at 03 57 24](https://github.com/Korea-Certified-Store/iOS/assets/62226667/8379eb52-2fe0-4d9a-b4af-d8ccb9d5ae86)|![Simulator Screen Recording - iPhone 15 - 2024-02-15 at 03 56 38](https://github.com/Korea-Certified-Store/iOS/assets/62226667/09a61031-8e3e-4c1c-8a57-d1cc82700ea0)|![Simulator Screen Recording - iPhone 15 - 2024-02-15 at 03 54 32](https://github.com/Korea-Certified-Store/iOS/assets/62226667/ca47e5d5-d854-4ff0-b51a-91aa90de387c)|
|--|--|--|

## 🛠️ Technical Concerns

### Keyboard Dismiss

ScrollView를 상속받는 TableView나 CollectionView의 경우 `.keyboardDismissMode`를 사용하면 drag 제스처를 통해 키보드를 dismiss시킬 수 있다.
`.keyboardDismissMode = .onDrag`를 이용하면 TableView에 drag 제스처가 들어가는 즉시 키보드가 내려가게 된다.
