### PR TITLE
검색어 자동 완성 기능 추가

### DIFF
--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -55,6 +55,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             )
         )
         let searchObserver = PublishRelay<String>()
+        let textObserver = PublishRelay<String>()
         let refreshCameraPositionObserver = BehaviorRelay<NMFCameraPosition>(value: NMFCameraPosition())
         let searchKeywordRepository = SearchKeywordRepositoryImpl(
             userDefaults: UserDefaults()
@@ -88,8 +89,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         repository: FetchAutoCompletionRepositoryImpl()
                     )
                 ),
-                searchObserver: searchObserver
-            ), 
+                searchObserver: searchObserver, 
+                textObserver: textObserver
+            ),
             summaryViewHeightObserver: summaryViewHeightObserver,
             listCellSelectedObserver: listCellSelectedObserver,
             searchObserver: searchObserver, 

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -83,6 +83,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     ), 
                     deleteAllHistoryUseCase: DeleteAllHistoryUseCaseImpl(
                         repository: searchKeywordRepository
+                    ), 
+                    getAutoCompletionUseCase: GetAutoCompletionUseCaseImpl(
+                        repository: FetchAutoCompletionRepositoryImpl()
                     )
                 ),
                 searchObserver: searchObserver

--- a/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
@@ -39,4 +39,3 @@ final class FetchAutoCompletionRepositoryImpl: FetchAutoCompletionRepository {
     }
     
 }
-

--- a/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
@@ -5,7 +5,8 @@
 //  Created by 조성민 on 2/12/24.
 //
 
-import UIKit
+import RxSwift
+import RxRelay
 
 final class AutoCompletionTableViewCell: UITableViewCell {
     
@@ -20,7 +21,7 @@ final class AutoCompletionTableViewCell: UITableViewCell {
         return imageView
     }()
     
-    private let keywordLabel: UILabel = {
+    private lazy var keywordLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = .black
@@ -28,6 +29,9 @@ final class AutoCompletionTableViewCell: UITableViewCell {
         
         return label
     }()
+    
+    private let disposeBag = DisposeBag()
+    var textObserver: PublishRelay<String>?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -42,6 +46,11 @@ final class AutoCompletionTableViewCell: UITableViewCell {
     
     func setUIContents(keyword: String) {
         keywordLabel.text = keyword
+    }
+    
+    func setObserver(textObserver: PublishRelay<String>) {
+        self.textObserver = textObserver
+        bind()
     }
     
 }
@@ -66,6 +75,16 @@ private extension AutoCompletionTableViewCell {
             keywordLabel.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
             keywordLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
         ])
+    }
+    
+    func bind() {
+        textObserver?.bind { [weak self] text in
+            guard let labelText = self?.keywordLabel.text else { return }
+            let attributedString = NSMutableAttributedString(string: labelText)
+            attributedString.addAttribute(.foregroundColor, value: UIColor.primary3, range: (labelText as NSString).range(of: text))
+            self?.keywordLabel.attributedText = attributedString
+        }
+        .disposed(by: disposeBag)
     }
     
 }

--- a/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
+++ b/KCS/KCS/Presentation/Search/View/AutoCompletionTableViewCell.swift
@@ -23,6 +23,7 @@ final class AutoCompletionTableViewCell: UITableViewCell {
     private let keywordLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .black
         label.font = .pretendard(size: 16, weight: .medium)
         
         return label

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -152,7 +152,7 @@ final class SearchViewController: UIViewController {
         return view
     }()
     
-    private let emptyListLabel: UILabel = {
+    private let noHistoryLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "최근 검색 기록이 없습니다"
@@ -162,7 +162,7 @@ final class SearchViewController: UIViewController {
         return label
     }()
     
-    private lazy var emptyView: UIView = {
+    private lazy var noHistoryView: UIView = {
         let imageView = UIImageView(image: SystemImage.toast)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.tintColor = .placeholderText
@@ -171,7 +171,7 @@ final class SearchViewController: UIViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isHidden = true
         view.addSubview(imageView)
-        view.addSubview(emptyListLabel)
+        view.addSubview(noHistoryLabel)
         
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -181,8 +181,8 @@ final class SearchViewController: UIViewController {
         ])
         
         NSLayoutConstraint.activate([
-            emptyListLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 16),
-            emptyListLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            noHistoryLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 16),
+            noHistoryLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
         
         return view
@@ -252,7 +252,7 @@ private extension SearchViewController {
         view.addSubview(divideView)
         view.addSubview(recentHistoryTableView)
         view.addSubview(autoCompletionTableView)
-        recentHistoryTableView.addSubview(emptyView)
+        recentHistoryTableView.addSubview(noHistoryView)
     }
     
     func configureConstraints() {
@@ -278,8 +278,8 @@ private extension SearchViewController {
         ])
         
         NSLayoutConstraint.activate([
-            emptyView.topAnchor.constraint(equalTo: divideView.bottomAnchor, constant: 179),
-            emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            noHistoryView.topAnchor.constraint(equalTo: divideView.bottomAnchor, constant: 179),
+            noHistoryView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
         
         NSLayoutConstraint.activate([
@@ -300,7 +300,7 @@ private extension SearchViewController {
     func bind() {
         viewModel.recentSearchKeywordsOutput
             .bind { [weak self] keywords in
-                self?.emptyView.isHidden = true
+                self?.noHistoryView.isHidden = true
                 self?.recentHistoryTableView.isHidden = false
                 self?.autoCompletionTableView.isHidden = true
                 self?.generateRecentHistoryData(data: keywords)
@@ -336,7 +336,7 @@ private extension SearchViewController {
         viewModel.noRecentHistoryOutput
             .bind { [weak self] in
                 guard let self = self else { return }
-                emptyView.isHidden = false
+                noHistoryView.isHidden = false
             }
             .disposed(by: disposeBag)
         

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -152,15 +152,10 @@ final class SearchViewController: UIViewController {
         return view
     }()
     
-    enum EmptyLabelText: String {
-        case autoCompletion = "에 대한 결과가 없습니다"
-        case recentHistory = "최근 검색 기록이 없습니다"
-    }
-    
     private let emptyListLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = EmptyLabelText.recentHistory.rawValue
+        label.text = "최근 검색 기록이 없습니다"
         label.font = UIFont.pretendard(size: 14, weight: .medium)
         label.textColor = .placeholderText
         
@@ -314,7 +309,6 @@ private extension SearchViewController {
         
         viewModel.autoCompleteKeywordsOutput
             .bind { [weak self] keywords in
-                self?.emptyView.isHidden = true
                 self?.recentHistoryTableView.isHidden = true
                 self?.autoCompletionTableView.isHidden = false
                 self?.generateAutoCompletionData(data: keywords)
@@ -342,19 +336,6 @@ private extension SearchViewController {
         viewModel.noRecentHistoryOutput
             .bind { [weak self] in
                 guard let self = self else { return }
-                recentHistoryTableView.addSubview(emptyView)
-                emptyListLabel.text = EmptyLabelText.recentHistory.rawValue
-                emptyListLabel.isHidden = false
-                emptyView.isHidden = false
-            }
-            .disposed(by: disposeBag)
-        
-        viewModel.noAutoCompletionOutput
-            .bind { [weak self] keyword in
-                guard let self = self else { return }
-                autoCompletionTableView.addSubview(emptyView)
-                emptyListLabel.text = "'\(keyword)'" + EmptyLabelText.autoCompletion.rawValue
-                emptyListLabel.isHidden = false
                 emptyView.isHidden = false
             }
             .disposed(by: disposeBag)

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -452,6 +452,10 @@ extension SearchViewController: UITableViewDelegate {
             guard let keyword = recentHistoryDataSource.itemIdentifier(for: indexPath) else { return }
             search(text: keyword)
         }
+        if tableView == autoCompletionTableView {
+            guard let keyword = autoCompletionDataSource.itemIdentifier(for: indexPath) else { return }
+            search(text: keyword)
+        }
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -37,6 +37,7 @@ protocol SearchViewModelOutput {
     
     var recentSearchKeywordsOutput: PublishRelay<[String]> { get }
     var autoCompleteKeywordsOutput: PublishRelay<[String]> { get }
+    var changeTextColorOutput: PublishRelay<String> { get }
     var searchOutput: PublishRelay<String> { get }
     var noKeywordToastOutput: PublishRelay<Void> { get }
     var noRecentHistoryOutput: PublishRelay<Void> { get }

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -39,5 +39,7 @@ protocol SearchViewModelOutput {
     var autoCompleteKeywordsOutput: PublishRelay<[String]> { get }
     var searchOutput: PublishRelay<String> { get }
     var noKeywordToastOutput: PublishRelay<Void> { get }
+    var noRecentHistoryOutput: PublishRelay<Void> { get }
+    var noAutoCompletionOutput: PublishRelay<String> { get }
     
 }

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -41,6 +41,5 @@ protocol SearchViewModelOutput {
     var searchOutput: PublishRelay<String> { get }
     var noKeywordToastOutput: PublishRelay<Void> { get }
     var noRecentHistoryOutput: PublishRelay<Void> { get }
-    var noAutoCompletionOutput: PublishRelay<String> { get }
     
 }

--- a/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/Protocol/SearchViewModel.swift
@@ -13,6 +13,7 @@ protocol SearchViewModel: SearchViewModelInput, SearchViewModelOutput {
     var saveRecentSearchKeywordUseCase: SaveRecentSearchKeywordUseCase { get }
     var deleteRecentSearchKeywordUseCase: DeleteRecentSearchKeywordUseCase { get }
     var deleteAllHistoryUseCase: DeleteAllHistoryUseCase { get }
+    var getAutoCompletionUseCase: GetAutoCompletionUseCase { get }
     
 }
 

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -24,7 +24,6 @@ final class SearchViewModelImpl: SearchViewModel {
     let searchOutput = PublishRelay<String>()
     let noKeywordToastOutput = PublishRelay<Void>()
     let noRecentHistoryOutput = PublishRelay<Void>()
-    let noAutoCompletionOutput = PublishRelay<String>()
     
     init(
         fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCase,
@@ -67,9 +66,6 @@ private extension SearchViewModelImpl {
                 .bind { [weak self] keywords in
                     self?.autoCompleteKeywordsOutput.accept(keywords)
                     self?.changeTextColorOutput.accept(text)
-                    if keywords.isEmpty {
-                        self?.noAutoCompletionOutput.accept(text)
-                    }
                 }
                 .disposed(by: disposeBag)
         }

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -16,22 +16,25 @@ final class SearchViewModelImpl: SearchViewModel {
     var saveRecentSearchKeywordUseCase: SaveRecentSearchKeywordUseCase
     var deleteRecentSearchKeywordUseCase: DeleteRecentSearchKeywordUseCase
     var deleteAllHistoryUseCase: DeleteAllHistoryUseCase
+    var getAutoCompletionUseCase: GetAutoCompletionUseCase
     
     let recentSearchKeywordsOutput = PublishRelay<[String]>()
     let autoCompleteKeywordsOutput = PublishRelay<[String]>()
     let searchOutput = PublishRelay<String>()
-    var noKeywordToastOutput = PublishRelay<Void>()
+    let noKeywordToastOutput = PublishRelay<Void>()
     
     init(
         fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCase,
         saveRecentSearchKeywordUseCase: SaveRecentSearchKeywordUseCase,
         deleteRecentSearchKeywordUseCase: DeleteRecentSearchKeywordUseCase,
-        deleteAllHistoryUseCase: DeleteAllHistoryUseCase
+        deleteAllHistoryUseCase: DeleteAllHistoryUseCase,
+        getAutoCompletionUseCase: GetAutoCompletionUseCase
     ) {
         self.fetchRecentSearchKeywordUseCase = fetchRecentSearchKeywordUseCase
         self.saveRecentSearchKeywordUseCase = saveRecentSearchKeywordUseCase
         self.deleteRecentSearchKeywordUseCase = deleteRecentSearchKeywordUseCase
         self.deleteAllHistoryUseCase = deleteAllHistoryUseCase
+        self.getAutoCompletionUseCase = getAutoCompletionUseCase
     }
     
     func action(input: SearchViewModelInputCase) {
@@ -57,8 +60,11 @@ private extension SearchViewModelImpl {
         if text.isEmpty {
             emitRecentHistory()
         } else {
-            // TODO: autoCompletion usecase 실행(debounce) 후 generateDataOutput.accept([]) (자동완성으로 전환)
-            emitRecentHistory()
+            getAutoCompletionUseCase.execute(keyword: text)
+                .bind { [weak self] keywords in
+                    self?.autoCompleteKeywordsOutput.accept(keywords)
+                }
+                .disposed(by: disposeBag)
         }
     }
      

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -22,6 +22,8 @@ final class SearchViewModelImpl: SearchViewModel {
     let autoCompleteKeywordsOutput = PublishRelay<[String]>()
     let searchOutput = PublishRelay<String>()
     let noKeywordToastOutput = PublishRelay<Void>()
+    let noRecentHistoryOutput = PublishRelay<Void>()
+    let noAutoCompletionOutput = PublishRelay<String>()
     
     init(
         fetchRecentSearchKeywordUseCase: FetchRecentSearchKeywordUseCase,
@@ -63,6 +65,9 @@ private extension SearchViewModelImpl {
             getAutoCompletionUseCase.execute(keyword: text)
                 .bind { [weak self] keywords in
                     self?.autoCompleteKeywordsOutput.accept(keywords)
+                    if keywords.isEmpty {
+                        self?.noAutoCompletionOutput.accept(text)
+                    }
                 }
                 .disposed(by: disposeBag)
         }
@@ -87,7 +92,11 @@ private extension SearchViewModelImpl {
     func emitRecentHistory() {
         fetchRecentSearchKeywordUseCase.execute()
             .bind { [weak self] keywords in
+                dump(keywords)
                 self?.recentSearchKeywordsOutput.accept(keywords)
+                if keywords.isEmpty {
+                    self?.noRecentHistoryOutput.accept(())
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Search/ViewModel/SearchViewModelImpl.swift
@@ -20,6 +20,7 @@ final class SearchViewModelImpl: SearchViewModel {
     
     let recentSearchKeywordsOutput = PublishRelay<[String]>()
     let autoCompleteKeywordsOutput = PublishRelay<[String]>()
+    let changeTextColorOutput = PublishRelay<String>()
     let searchOutput = PublishRelay<String>()
     let noKeywordToastOutput = PublishRelay<Void>()
     let noRecentHistoryOutput = PublishRelay<Void>()
@@ -65,6 +66,7 @@ private extension SearchViewModelImpl {
             getAutoCompletionUseCase.execute(keyword: text)
                 .bind { [weak self] keywords in
                     self?.autoCompleteKeywordsOutput.accept(keywords)
+                    self?.changeTextColorOutput.accept(text)
                     if keywords.isEmpty {
                         self?.noAutoCompletionOutput.accept(text)
                     }
@@ -92,7 +94,6 @@ private extension SearchViewModelImpl {
     func emitRecentHistory() {
         fetchRecentSearchKeywordUseCase.execute()
             .bind { [weak self] keywords in
-                dump(keywords)
                 self?.recentSearchKeywordsOutput.accept(keywords)
                 if keywords.isEmpty {
                     self?.noRecentHistoryOutput.accept(())


### PR DESCRIPTION
## ⭐️ Issue Number

- #263 

## 🚩 Summary

- 검색어 자동 완성 기능을 추가한다
- 검색어 자동 완성에서 특정 문자열의 색상을 변경시킨다
- 최근 검색어가 없는 경우 특정 View를 띄워준다

|![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 01 01 38](https://github.com/Korea-Certified-Store/iOS/assets/62226667/934c6731-7394-4876-b8b5-80707b516392)|![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 00 59 57](https://github.com/Korea-Certified-Store/iOS/assets/62226667/24e44e7c-0179-40e1-bc7b-3042af70cefc)|![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 01 01 51](https://github.com/Korea-Certified-Store/iOS/assets/62226667/e93887d9-df59-4507-9213-b3f9a62ebd8e)|
|:--:|:--:|:--:|
|자동 완성 기능|특정 문자열 색상 변경|최근 검색어 없는 경우|


## 🛠️ Technical Concerns

### 자동 완성 cell의 textColor 변경 타이밍 

figma에 따르면 검색창에 검색어를 입력하면 자동 완성 결과값과 비교하여 검색어와 동일한 문자열의 색상을 특정 색상으로 설정해야했다.
이를 해결하기 위해 `textObserver`를 `SearchViewController`에서 생성하여 cell로 주입시키고 자동 완성에 대한 결과값이 나오는 시점에 검색어를 cell로 `.accept` 해주었다.
처음에 `TextLabel`의 색상을 변경시켜주는 시점을 cell이 생성되는 시점으로 설정해 주었는데 이렇게되면 `textObserver`가 `ViewController`와 아직 연결되지 않은 시점에 색상을 변경시켜주게 되어 원하는 기능을 구현하기 힘들었다. 따라서 `textObserver`를 연동시켜준 후 binding을 하여 싱크를 맞춰주었고, 원하는 기능을 구현할 수 있게 되었다.