### PR TITLE
카카오 주소 API 연동

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		A8AF06762B80BE1000E73574 /* FetchAutoCompletionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF06752B80BE1000E73574 /* FetchAutoCompletionRepository.swift */; };
 		A8AF06782B80BE7200E73574 /* GetAutoCompletionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF06772B80BE7200E73574 /* GetAutoCompletionUseCase.swift */; };
 		A8AF067A2B80BEE300E73574 /* GetAutoCompletionUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF06792B80BEE300E73574 /* GetAutoCompletionUseCaseImpl.swift */; };
+		A8AF067F2B8121F300E73574 /* AddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF067E2B8121F300E73574 /* AddressViewController.swift */; };
 		A8CD526A2B7B7DFE00917786 /* CellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CD52692B7B7DFD00917786 /* CellDelegate.swift */; };
 		A8E53C252B77DDF3003FCBA2 /* StoreStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */; };
 		A8E53C272B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */; };
@@ -318,6 +319,7 @@
 		A8AF06752B80BE1000E73574 /* FetchAutoCompletionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAutoCompletionRepository.swift; sourceTree = "<group>"; };
 		A8AF06772B80BE7200E73574 /* GetAutoCompletionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAutoCompletionUseCase.swift; sourceTree = "<group>"; };
 		A8AF06792B80BEE300E73574 /* GetAutoCompletionUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAutoCompletionUseCaseImpl.swift; sourceTree = "<group>"; };
+		A8AF067E2B8121F300E73574 /* AddressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressViewController.swift; sourceTree = "<group>"; };
 		A8CD52692B7B7DFD00917786 /* CellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellDelegate.swift; sourceTree = "<group>"; };
 		A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStorage.swift; sourceTree = "<group>"; };
 		A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoresRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -561,12 +563,13 @@
 		5986DCDF2B3892EB005AE43B /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				59503A6D2B7FB2EB0006CF35 /* NewStoreRequest */,
 				A890870B2B4EF8F900767225 /* Extension */,
 				5986DCEA2B392996005AE43B /* Home */,
 				59B886242B6A39E9005750EF /* StoreList */,
 				59B886552B6E3A59005750EF /* StoreInformation */,
 				59503A4B2B751AEE0006CF35 /* Search */,
+				59503A6D2B7FB2EB0006CF35 /* NewStoreRequest */,
+				A8AF067B2B8121B800E73574 /* Address */,
 				A83367B92B709BE900E0A844 /* OnBoarding */,
 				A821A3722B74B82600089B8F /* Splash */,
 			);
@@ -916,6 +919,30 @@
 				A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		A8AF067B2B8121B800E73574 /* Address */ = {
+			isa = PBXGroup;
+			children = (
+				A8AF067C2B8121DB00E73574 /* View */,
+				A8AF067D2B8121E000E73574 /* VIewModel */,
+			);
+			path = Address;
+			sourceTree = "<group>";
+		};
+		A8AF067C2B8121DB00E73574 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A8AF067E2B8121F300E73574 /* AddressViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A8AF067D2B8121E000E73574 /* VIewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = VIewModel;
 			sourceTree = "<group>";
 		};
 		E99F20FF9A30DCF9C51285A2 /* Frameworks */ = {
@@ -1289,6 +1316,7 @@
 				A86D92192B761EC7003B9FEE /* SearchKeywordsRepository.swift in Sources */,
 				59C306DC2B506F3D00862625 /* NetworkError.swift in Sources */,
 				59C306C32B50114100862625 /* Day.swift in Sources */,
+				A8AF067F2B8121F300E73574 /* AddressViewController.swift in Sources */,
 				59C306AD2B4FFAC700862625 /* StoreDTO.swift in Sources */,
 				59C306A92B4FF9AF00862625 /* StoreRepository.swift in Sources */,
 				5977BE982B5999E000725C90 /* GetRefreshStoresUseCaseImpl.swift in Sources */,

--- a/KCS/KCS/Presentation/Address/View/AddressViewController.swift
+++ b/KCS/KCS/Presentation/Address/View/AddressViewController.swift
@@ -1,0 +1,100 @@
+//
+//  AddressViewController.swift
+//  KCS
+//
+//  Created by 김영현 on 2/18/24.
+//
+
+import WebKit
+
+final class AddressViewController: UIViewController {
+    
+    private let loadIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        return indicator
+    }()
+    
+    private lazy var addressContentController: WKUserContentController = {
+        let contentController = WKUserContentController()
+        contentController.add(self, name: "callBackHandler")
+        
+        return contentController
+    }()
+    
+    private lazy var addressConfiguration: WKWebViewConfiguration = {
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = addressContentController
+        
+        return configuration
+    }()
+    
+    private lazy var addressWebView: WKWebView = {
+        let webView = WKWebView(frame: .zero, configuration: addressConfiguration)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        
+        return webView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addUIComponents()
+        configureConstraints()
+        setWebView()
+    }
+}
+
+private extension AddressViewController {
+    
+    func addUIComponents() {
+        view.addSubview(addressWebView)
+        view.addSubview(loadIndicator)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            addressWebView.topAnchor.constraint(equalTo: view.topAnchor),
+            addressWebView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            addressWebView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            addressWebView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            loadIndicator.centerXAnchor.constraint(equalTo: addressWebView.centerXAnchor),
+            loadIndicator.centerYAnchor.constraint(equalTo: addressWebView.centerYAnchor)
+        ])
+    }
+    
+    func setWebView() {
+        guard let url = URL(string: "https://korea-certified-store.github.io/KakaoAddressWeb/") else { return }
+        addressWebView.load(URLRequest(url: url))
+        loadIndicator.startAnimating()
+    }
+    
+}
+
+extension AddressViewController: WKScriptMessageHandler {
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let data = message.body as? [String: Any],
+              let address = data["roadAddress"] as? String else { return }
+        
+        // TODO: address 주소 사용 코드 작성 필요
+    }
+    
+}
+
+extension AddressViewController: WKNavigationDelegate {
+    
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        loadIndicator.startAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loadIndicator.stopAnimating()
+    }
+    
+}

--- a/KCS/KCS/Presentation/Address/View/AddressViewController.swift
+++ b/KCS/KCS/Presentation/Address/View/AddressViewController.swift
@@ -10,28 +10,20 @@ import WebKit
 final class AddressViewController: UIViewController {
     
     private let loadIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .medium)
+        let indicator = UIActivityIndicatorView(style: .large)
         indicator.translatesAutoresizingMaskIntoConstraints = false
         
         return indicator
     }()
     
-    private lazy var addressContentController: WKUserContentController = {
+    private lazy var addressWebView: WKWebView = {
         let contentController = WKUserContentController()
         contentController.add(self, name: "callBackHandler")
         
-        return contentController
-    }()
-    
-    private lazy var addressConfiguration: WKWebViewConfiguration = {
         let configuration = WKWebViewConfiguration()
-        configuration.userContentController = addressContentController
+        configuration.userContentController = contentController
         
-        return configuration
-    }()
-    
-    private lazy var addressWebView: WKWebView = {
-        let webView = WKWebView(frame: .zero, configuration: addressConfiguration)
+        let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
         


### PR DESCRIPTION
## ⭐️ Issue Number

- #267 

## 🚩 Summary

- 카카오 주소 Web 페이지를 생성한다
- 생성한 카카오 주소 Web 페이지를 WebView를 사용하여 앱에 띄워준다

![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 02 51 58](https://github.com/Korea-Certified-Store/iOS/assets/62226667/b6bc1ceb-c76c-4eb5-b7d8-3c0654b2d954)

## 🛠️ Technical Concerns

### WebKit을 사용하여 카카오 우편번호 서비스 구현

카카오 우편번호 서비스는 SDK나 라이브러리를 사용하는 것이 아니고, 따로 웹을 생성하여 웹을 앱 내에서 띄워주는 형태를 띄우고 있다.
따라서 KCS Organization에 카카오 우편 웹을 띄워줄 repository를 새로 생성한 후 Git Page를 사용하여 우리 앱에서 사용할 우편번호 웹을 만들어주었다.

그리고 앱에서 사용하기 위해 웹을 띄워줄 `AddressViewController`를 생성해 주었다.
사용자가 선택한 주소를 사용하기 위해선 `WKScriptMessageHandler`가 필요하다. `AddressViewController`에서 `WKScriptMessageHandler`를 채택하고 아래와 같은 함수를 생성하게되면 해당 함수 내에서 사용자가 선택한 주소에 대한 데이터를 처리할 수 있게 된다.

```swift
func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
    // address 주소 사용 코드
}
```

## 🔗 참고자료

- [KCS kakao web](https://korea-certified-store.github.io/KakaoAddressWeb/)
- [kakao 우편번호 서비스](https://postcode.map.daum.net/guide?source=post_page-----f2d989e9a9e--------------------------------#sample)
- [kakao 우편번호 서비스 구현 1](https://kasroid.github.io/posts/ios/20200916-webkit-search-address-with-kakao-with-uikit/)
- [kakao 우편번호 서비스 구현 2](https://nsios.tistory.com/158)