### PR TITLE
RequestUpdateStoreViewController 레이아웃 구현

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		59503A722B7FB38E0006CF35 /* NewStoreTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A712B7FB38E0006CF35 /* NewStoreTextField.swift */; };
 		59503A752B80A2980006CF35 /* NewStoreRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A742B80A2980006CF35 /* NewStoreRequestViewModel.swift */; };
 		59503A782B80A2AF0006CF35 /* NewStoreRequestViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A772B80A2AF0006CF35 /* NewStoreRequestViewModelImpl.swift */; };
+		59503A7C2B80E8650006CF35 /* StoreUpdateRequestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A7B2B80E8650006CF35 /* StoreUpdateRequestViewController.swift */; };
+		59503A802B80ED2C0006CF35 /* StoreUpdateRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A7F2B80ED2C0006CF35 /* StoreUpdateRequestViewModel.swift */; };
+		59503A822B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A812B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift */; };
 		595EE2A52B693DE700CC01CE /* ErrorAlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */; };
 		596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */; };
 		5977BE582B5524D500725C90 /* RefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5977BE572B5524D500725C90 /* RefreshButton.swift */; };
@@ -195,6 +198,9 @@
 		59503A712B7FB38E0006CF35 /* NewStoreTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreTextField.swift; sourceTree = "<group>"; };
 		59503A742B80A2980006CF35 /* NewStoreRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestViewModel.swift; sourceTree = "<group>"; };
 		59503A772B80A2AF0006CF35 /* NewStoreRequestViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestViewModelImpl.swift; sourceTree = "<group>"; };
+		59503A7B2B80E8650006CF35 /* StoreUpdateRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestViewController.swift; sourceTree = "<group>"; };
+		59503A7F2B80ED2C0006CF35 /* StoreUpdateRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestViewModel.swift; sourceTree = "<group>"; };
+		59503A812B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestViewModelImpl.swift; sourceTree = "<group>"; };
 		595EE2A42B693DE700CC01CE /* ErrorAlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertMessage.swift; sourceTree = "<group>"; };
 		596DDC4C2B6416AB00A4BBC4 /* SummaryViewContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewContents.swift; sourceTree = "<group>"; };
 		5977BE572B5524D500725C90 /* RefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshButton.swift; sourceTree = "<group>"; };
@@ -454,6 +460,40 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		59503A792B80E8260006CF35 /* StoreUpdateRequest */ = {
+			isa = PBXGroup;
+			children = (
+				59503A7D2B80ED160006CF35 /* ViewModel */,
+				59503A7A2B80E84A0006CF35 /* View */,
+			);
+			path = StoreUpdateRequest;
+			sourceTree = "<group>";
+		};
+		59503A7A2B80E84A0006CF35 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				59503A7B2B80E8650006CF35 /* StoreUpdateRequestViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		59503A7D2B80ED160006CF35 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				59503A7E2B80ED1E0006CF35 /* Protocol */,
+				59503A812B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		59503A7E2B80ED1E0006CF35 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				59503A7F2B80ED2C0006CF35 /* StoreUpdateRequestViewModel.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		5977BE592B55355D00725C90 /* protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -561,6 +601,7 @@
 		5986DCDF2B3892EB005AE43B /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				59503A792B80E8260006CF35 /* StoreUpdateRequest */,
 				59503A6D2B7FB2EB0006CF35 /* NewStoreRequest */,
 				A890870B2B4EF8F900767225 /* Extension */,
 				5986DCEA2B392996005AE43B /* Home */,
@@ -1240,6 +1281,7 @@
 				5977BE9E2B59ACE800725C90 /* ImageCache.swift in Sources */,
 				59B886642B6EC816005750EF /* SummaryViewHeightCase.swift in Sources */,
 				59C306A42B4D7EBA00862625 /* Marker.swift in Sources */,
+				59503A802B80ED2C0006CF35 /* StoreUpdateRequestViewModel.swift in Sources */,
 				59B886462B6A5CDC005750EF /* StoreListViewModel.swift in Sources */,
 				A8E53C2B2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift in Sources */,
 				59B8865E2B6E4B98005750EF /* StoreInformationViewModelImpl.swift in Sources */,
@@ -1257,6 +1299,7 @@
 				A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */,
 				59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */,
 				A8ACB7D82B57BE7D00540BD1 /* StoreRepositoryError.swift in Sources */,
+				59503A7C2B80E8650006CF35 /* StoreUpdateRequestViewController.swift in Sources */,
 				59B8864A2B6A9CCB005750EF /* UIStackView+clear.swift in Sources */,
 				59C306C72B501B1E00862625 /* JSONContentsError.swift in Sources */,
 				A8E53C252B77DDF3003FCBA2 /* StoreStorage.swift in Sources */,
@@ -1268,6 +1311,7 @@
 				59C306B62B50027300862625 /* Store.swift in Sources */,
 				59C306B42B50015500862625 /* APIResponse.swift in Sources */,
 				A8722EFE2B7644D7001ED988 /* FetchRecentSearchKeywordUseCaseImpl.swift in Sources */,
+				59503A822B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift in Sources */,
 				59B8865A2B6E3B40005750EF /* StoreInformationViewController.swift in Sources */,
 				A81B5A682B7C81DB0042307A /* DeleteAllHistoryUseCase.swift in Sources */,
 				A8722F002B7644E0001ED988 /* FetchRecentSearchKeywordUseCase.swift in Sources */,

--- a/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreTextField.swift
+++ b/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreTextField.swift
@@ -74,7 +74,6 @@ final class NewStoreTextField: UITextField {
 private extension NewStoreTextField {
     
     func setup() {
-        clearButtonMode = .whileEditing
         leftViewMode = .always
         leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
         rightViewMode = .whileEditing

--- a/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
@@ -1,0 +1,287 @@
+//
+//  StoreUpdateRequestViewController.swift
+//  KCS
+//
+//  Created by 조성민 on 2/17/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class StoreUpdateRequestViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    
+    private let typeHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고 유형"
+        label.font = .pretendard(size: 14, weight: .medium)
+        label.textColor = .kcsGray1
+        
+        return label
+    }()
+    
+    private lazy var typeTextField: NewStoreTextField = {
+        let textField = NewStoreTextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        
+        let pickerView = UIPickerView()
+        pickerView.dataSource = self
+        pickerView.delegate = self
+        
+        let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.bounds.size.width, height: 44))
+        let selectButton = UIBarButtonItem(
+            title: "확인",
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        selectButton.rx.tap
+            .bind { [weak self] _ in
+                // TODO: 확인 버튼 눌렀을 때 동작 구현
+            }
+            .disposed(by: disposeBag)
+        
+        let flexibleButton = UIBarButtonItem(systemItem: .flexibleSpace)
+        toolBar.setItems([flexibleButton, selectButton], animated: true)
+        
+        textField.rightViewMode = .never
+        textField.inputAccessoryView = toolBar
+        textField.inputView = pickerView
+        
+        textField.rx.controlEvent([.editingDidBegin])
+            .bind { [weak self] _ in
+                textField.setSelectedUI()
+                self?.typeWarningLabel.isHidden = true
+            }
+            .disposed(by: disposeBag)
+        
+        textField.rx.controlEvent([.editingDidEnd])
+            .bind { [weak self] _ in
+                guard let text = textField.text else { return }
+                self?.viewModel.action(input: .typeInput(text: text))
+            }
+            .disposed(by: disposeBag)
+        
+        return textField
+    }()
+    
+    private let typeWarningLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고 유형을 선택해 주세요."
+        label.font = .pretendard(size: 12, weight: .regular)
+        label.textColor = .uiTextFieldWarning
+        label.isHidden = true
+        
+        return label
+    }()
+    
+    private let contentHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고 내용"
+        label.font = .pretendard(size: 14, weight: .medium)
+        label.textColor = .kcsGray1
+        
+        return label
+    }()
+    
+    private lazy var contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.setLayerCorner(cornerRadius: 10)
+        textView.font = .pretendard(size: 15, weight: .medium)
+        textView.layer.borderWidth = 1.5
+        textView.contentInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        textView.delegate = self
+        textView.rx.didBeginEditing
+            .bind { [weak self] _ in
+                self?.setSelectedUI()
+            }
+            .disposed(by: disposeBag)
+    
+        textView.rx.didEndEditing
+            .bind { [weak self] _ in
+                guard let text = textView.text else { return }
+                self?.viewModel.action(input: .contentInput(text: text))
+            }
+            .disposed(by: disposeBag)
+        
+        return textView
+    }()
+    
+    private let contentWarningLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고 내용을 작성해 주세요."
+        label.font = .pretendard(size: 12, weight: .regular)
+        label.textColor = .uiTextFieldWarning
+        label.isHidden = true
+        
+        return label
+    }()
+    
+    private let viewModel: StoreUpdateRequestViewModel
+    
+    init(viewModel: StoreUpdateRequestViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addUIComponents()
+        configureConstraints()
+        setup()
+        bind()
+    }
+    
+}
+
+private extension StoreUpdateRequestViewController {
+    
+    func addUIComponents() {
+        view.addSubview(typeHeaderLabel)
+        view.addSubview(typeTextField)
+        view.addSubview(typeWarningLabel)
+        view.addSubview(contentHeaderLabel)
+        view.addSubview(contentTextView)
+        view.addSubview(contentWarningLabel)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            typeHeaderLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            typeHeaderLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 35)
+        ])
+        
+        NSLayoutConstraint.activate([
+            typeTextField.topAnchor.constraint(equalTo: typeHeaderLabel.bottomAnchor, constant: 8),
+            typeTextField.leadingAnchor.constraint(equalTo: typeHeaderLabel.leadingAnchor),
+            typeTextField.widthAnchor.constraint(equalToConstant: 144),
+            typeTextField.heightAnchor.constraint(equalToConstant: 50)
+        ])
+        
+        NSLayoutConstraint.activate([
+            typeWarningLabel.topAnchor.constraint(equalTo: typeTextField.bottomAnchor, constant: 6),
+            typeWarningLabel.leadingAnchor.constraint(equalTo: typeTextField.leadingAnchor, constant: 16)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentHeaderLabel.topAnchor.constraint(equalTo: typeTextField.bottomAnchor, constant: 48),
+            contentHeaderLabel.leadingAnchor.constraint(equalTo: typeTextField.leadingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentTextView.topAnchor.constraint(equalTo: contentHeaderLabel.bottomAnchor, constant: 8),
+            contentTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
+            contentTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8),
+            contentTextView.heightAnchor.constraint(equalToConstant: 200)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentWarningLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 6),
+            contentWarningLabel.leadingAnchor.constraint(equalTo: contentTextView.leadingAnchor, constant: 16)
+        ])
+    }
+    
+    func setup() {
+        view.backgroundColor = .white
+        setNormalUI()
+    }
+    
+    func bind() {
+        viewModel.typeEditEndOutput
+            .bind { [weak self] in
+                self?.typeTextField.setNormalUI()
+                self?.typeWarningLabel.isHidden = true
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.typeWarningOutput
+            .bind { [weak self] in
+                self?.typeTextField.setWarningUI()
+                self?.typeWarningLabel.isHidden = false
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.contentEditEndOutput
+            .bind { [weak self] in
+                self?.setSelectedUI()
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.contentWarningOutput
+            .bind { [weak self] in
+                self?.setWarningUI()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}
+
+private extension StoreUpdateRequestViewController {
+    
+    func setSelectedUI() {
+        contentTextView.backgroundColor = .newStoreRequestTextFieldEdit
+        contentTextView.layer.borderWidth = 1.5
+        contentTextView.layer.borderColor = UIColor.uiTextFieldBoldBorder.cgColor
+        contentWarningLabel.isHidden = true
+    }
+    
+    func setWarningUI() {
+        contentTextView.backgroundColor = .newStoreRequestTextFieldNormal
+        contentTextView.layer.borderWidth = 1.5
+        contentTextView.layer.borderColor = UIColor.uiTextFieldWarning.cgColor
+        contentWarningLabel.isHidden = false
+    }
+    
+    func setNormalUI() {
+        contentTextView.backgroundColor = .newStoreRequestTextFieldNormal
+        contentTextView.layer.borderWidth = 0.7
+        contentTextView.layer.borderColor = UIColor.uiTextFieldNormalBorder.cgColor
+        contentWarningLabel.isHidden = true
+    }
+}
+
+extension StoreUpdateRequestViewController: UITextViewDelegate {
+    
+}
+
+extension StoreUpdateRequestViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return 3
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        switch row {
+        case 0:
+            return "수정"
+        case 1:
+            return "삭제"
+        case 2:
+            return "기타"
+        default:
+            return nil
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        // TODO: 선택했을때 동작
+    }
+    
+}

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
@@ -20,7 +20,8 @@ protocol StoreUpdateRequestViewModelInput {
 enum StoreUpdateRequestViewModelInputCase {
     
     case typeInput(text: String)
-    case contentInput(text: String)
+    case contentEndEditing(text: String)
+    case contentWhileEditing(text: String)
     
 }
 
@@ -30,5 +31,7 @@ protocol StoreUpdateRequestViewModelOutput {
     var typeEditEndOutput: PublishRelay<Void> { get }
     var contentWarningOutput: PublishRelay<Void> { get }
     var contentEditEndOutput: PublishRelay<Void> { get }
+    var contentErasePlaceHolder: PublishRelay<Void> { get }
+    var contentFillPlaceHolder: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  StoreUpdateRequestViewModel.swift
+//  KCS
+//
+//  Created by 조성민 on 2/17/24.
+//
+
+import RxRelay
+
+protocol StoreUpdateRequestViewModel: StoreUpdateRequestViewModelInput, StoreUpdateRequestViewModelOutput {
+    
+}
+
+protocol StoreUpdateRequestViewModelInput {
+    
+    func action(input: StoreUpdateRequestViewModelInputCase)
+    
+}
+
+enum StoreUpdateRequestViewModelInputCase {
+    
+    case typeInput(text: String)
+    case contentInput(text: String)
+    
+}
+
+protocol StoreUpdateRequestViewModelOutput {
+    
+    var typeWarningOutput: PublishRelay<Void> { get }
+    var typeEditEndOutput: PublishRelay<Void> { get }
+    var contentWarningOutput: PublishRelay<Void> { get }
+    var contentEditEndOutput: PublishRelay<Void> { get }
+    
+}

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -13,13 +13,17 @@ final class StoreUpdateRequestViewModelImpl: StoreUpdateRequestViewModel {
     let typeEditEndOutput = PublishRelay<Void>()
     let contentWarningOutput = PublishRelay<Void>()
     let contentEditEndOutput = PublishRelay<Void>()
+    let contentErasePlaceHolder = PublishRelay<Void>()
+    let contentFillPlaceHolder = PublishRelay<Void>()
     
     func action(input: StoreUpdateRequestViewModelInputCase) {
         switch input {
         case .typeInput(let text):
             typeInput(text: text)
-        case .contentInput(let text):
-            contentInput(text: text)
+        case .contentEndEditing(let text):
+            contentEndEditing(text: text)
+        case .contentWhileEditing(text: let text):
+            contentWhileEditing(text: text)
         }
     }
     
@@ -35,11 +39,19 @@ private extension StoreUpdateRequestViewModelImpl {
         }
     }
     
-    func contentInput(text: String) {
+    func contentEndEditing(text: String) {
         if text.isEmpty {
             contentWarningOutput.accept(())
         } else {
             contentEditEndOutput.accept(())
+        }
+    }
+    
+    func contentWhileEditing(text: String) {
+        if text.isEmpty {
+            contentFillPlaceHolder.accept(())
+        } else {
+            contentErasePlaceHolder.accept(())
         }
     }
     

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -1,0 +1,46 @@
+//
+//  StoreUpdateRequestViewModelImpl.swift
+//  KCS
+//
+//  Created by 조성민 on 2/17/24.
+//
+
+import RxRelay
+
+final class StoreUpdateRequestViewModelImpl: StoreUpdateRequestViewModel {
+    
+    let typeWarningOutput = PublishRelay<Void>()
+    let typeEditEndOutput = PublishRelay<Void>()
+    let contentWarningOutput = PublishRelay<Void>()
+    let contentEditEndOutput = PublishRelay<Void>()
+    
+    func action(input: StoreUpdateRequestViewModelInputCase) {
+        switch input {
+        case .typeInput(let text):
+            typeInput(text: text)
+        case .contentInput(let text):
+            contentInput(text: text)
+        }
+    }
+    
+}
+
+private extension StoreUpdateRequestViewModelImpl {
+    
+    func typeInput(text: String) {
+        if text.isEmpty {
+            typeWarningOutput.accept(())
+        } else {
+            typeEditEndOutput.accept(())
+        }
+    }
+    
+    func contentInput(text: String) {
+        if text.isEmpty {
+            contentWarningOutput.accept(())
+        } else {
+            contentEditEndOutput.accept(())
+        }
+    }
+    
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #265

## 🚩 Summary

- UITextField에 UIPickerView 적용
- PlaceHolder가 있는 UITextView 구현
- 반응형 Warning 구현

![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 06 00 47](https://github.com/Korea-Certified-Store/iOS/assets/128480641/a08276ad-4b37-40c7-8a0a-8f4fd3541e21)

## 🛠️ Technical Concerns

### PlaceHolder가 있는 UITextView 만들기
UITextField의 placeholder와 완벽하게 같은 기능을 하도록 했다.
인터넷에 흔히 알려진 방식은 UITextView가 선택되면 placeholder가 사라지기 때문에 UITextField의 placeholder와 시스템이 달랐다.

방법 1)
UITextView 변수 이름이 contentTextView일때,
contentTextView.text = "placeholder 내용"
입력을 위해 터치 : 커서를 맨 앞으로 이동.
입력 중 : text 값이 placeholder 내용과 다를 경우 placeholder를 지우고, color 변경

이렇게 진행하려고 했으나, 사용자가 입력을 위해 터치한 이후에 커서를 움직이면 placeholder의 중간에 커서를 둘 수 있게 된다.
그래서 방법1을 선택하지 않았다.

방법 2)
UITextView 속에 UILabel을 집어넣는다.
입력 중만 검사하면 된다.
text.isEmpty == true -> placeholdeLabel.isHidden = false
text.isEmpty == false -> placeholdeLabel.isHidden = true

이러한 방식으로 placeholder가 있는 UITextView를 완성했다.

### UI datasource를 ViewModel로 옮겨야할까?

UI에 대한 DataSource를 ViewModel로 옮겨야 한다고 생각했다.
그래서 DataSource를 ViewModel이 채택하도록 구현하려 했으나, ViewModel은 추상화된 View라는 이유로 UIKit을 import해서는 안된다.
그렇기 때문에 DataSource는 ViewController의 역할이라고 판단했다.

## 🙂 To Reviwer

- 반응형으로 ViewModel과 어떻게 바인딩했는지 보시면 좋을 것 같아요.
- UITextView의 PlaceHolder를 UILabel로 어떻게 구현했는지 보시면 좋을 것 같아요.

## 📋 To Do

- 신고 내용 최대 설정
- 네비게이션 설정
- 완료 버튼 활성화 조건 설정
- 완료 버튼 API 요청
