### PR TITLE
정보 수정 내용 최대 글자수 설정

### DIFF
--- a/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
@@ -117,6 +117,7 @@ final class StoreUpdateRequestViewController: UIViewController {
             .bind { [weak self] _ in
                 guard let text = textView.text else { return }
                 self?.viewModel.action(input: .contentWhileEditing(text: text))
+                self?.contentLengthLabel.text = "\(text.count)/300"
             }
             .disposed(by: disposeBag)
         
@@ -137,10 +138,20 @@ final class StoreUpdateRequestViewController: UIViewController {
     private let contentWarningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "신고 내용을 작성해 주세요."
+        label.text = "신고 내용을 수정해 주세요."
         label.font = .pretendard(size: 12, weight: .regular)
         label.textColor = .uiTextFieldWarning
         label.isHidden = true
+        
+        return label
+    }()
+    
+    private let contentLengthLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "0/300"
+        label.font = .pretendard(size: 12, weight: .regular)
+        label.textColor = .kcsGray1
         
         return label
     }()
@@ -177,6 +188,7 @@ private extension StoreUpdateRequestViewController {
         view.addSubview(contentHeaderLabel)
         view.addSubview(contentTextView)
         view.addSubview(contentWarningLabel)
+        view.addSubview(contentLengthLabel)
         contentTextView.addSubview(textViewPlaceHolderLabel)
     }
     
@@ -218,6 +230,11 @@ private extension StoreUpdateRequestViewController {
         NSLayoutConstraint.activate([
             contentWarningLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 6),
             contentWarningLabel.leadingAnchor.constraint(equalTo: contentTextView.leadingAnchor, constant: 16)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentLengthLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 8),
+            contentLengthLabel.trailingAnchor.constraint(equalTo: contentTextView.trailingAnchor)
         ])
     }
     
@@ -273,6 +290,17 @@ private extension StoreUpdateRequestViewController {
             }
             .disposed(by: disposeBag)
         
+        viewModel.contentLengthNormalOutput
+            .bind { [weak self] in
+                self?.contentLengthLabel.textColor = .kcsGray1
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.contentLengthWarningOutput
+            .bind { [weak self] in
+                self?.contentLengthLabel.textColor = .uiTextFieldWarning
+            }
+            .disposed(by: disposeBag)
     }
     
 }
@@ -291,6 +319,7 @@ private extension StoreUpdateRequestViewController {
         contentTextView.layer.borderWidth = 1.5
         contentTextView.layer.borderColor = UIColor.uiTextFieldWarning.cgColor
         contentWarningLabel.isHidden = false
+        contentLengthLabel.textColor = .uiTextFieldWarning
     }
     
     func setNormalUI() {

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/Protocol/StoreUpdateRequestViewModel.swift
@@ -33,5 +33,7 @@ protocol StoreUpdateRequestViewModelOutput {
     var contentEditEndOutput: PublishRelay<Void> { get }
     var contentErasePlaceHolder: PublishRelay<Void> { get }
     var contentFillPlaceHolder: PublishRelay<Void> { get }
+    var contentLengthWarningOutput: PublishRelay<Void> { get }
+    var contentLengthNormalOutput: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -15,6 +15,8 @@ final class StoreUpdateRequestViewModelImpl: StoreUpdateRequestViewModel {
     let contentEditEndOutput = PublishRelay<Void>()
     let contentErasePlaceHolder = PublishRelay<Void>()
     let contentFillPlaceHolder = PublishRelay<Void>()
+    let contentLengthWarningOutput = PublishRelay<Void>()
+    let contentLengthNormalOutput = PublishRelay<Void>()
     
     func action(input: StoreUpdateRequestViewModelInputCase) {
         switch input {
@@ -40,10 +42,12 @@ private extension StoreUpdateRequestViewModelImpl {
     }
     
     func contentEndEditing(text: String) {
-        if text.isEmpty {
+        if text.isEmpty || text.count > 300 {
             contentWarningOutput.accept(())
+            contentLengthWarningOutput.accept(())
         } else {
             contentEditEndOutput.accept(())
+            contentLengthNormalOutput.accept(())
         }
     }
     
@@ -52,6 +56,11 @@ private extension StoreUpdateRequestViewModelImpl {
             contentFillPlaceHolder.accept(())
         } else {
             contentErasePlaceHolder.accept(())
+        }
+        if text.isEmpty || text.count > 300 {
+            contentLengthWarningOutput.accept(())
+        } else {
+            contentLengthNormalOutput.accept(())
         }
     }
     


### PR DESCRIPTION
## ⭐️ Issue Number

- #271

## 🚩 Summary

- 수정 요청 View에서 내용의 최대 길이 설정

![Simulator Screen Recording - iPhone 15 - 2024-02-18 at 15 35 58](https://github.com/Korea-Certified-Store/iOS/assets/128480641/c36c4bd7-9ea7-4c54-83a8-43c18589c9f3)

## 🛠️ Technical Concerns

### 실시간 길이 Observing

사용자에게 실시간으로 글자수를 제공하고, 글자수가 최대치를 넘어갔을 때 사용자에게 즉각적으로 알리기 위해서 실시간으로 구현했다.
하지만 테두리와 Warning Label은 실시간이 아닌 Editing이 끝났을 때 작동하도록 구현했다.
