### PR TITLE
inputView가 있는 UITextField 사용자 Edit 방지

### DIFF
--- a/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreTextField.swift
+++ b/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreTextField.swift
@@ -83,3 +83,22 @@ private extension NewStoreTextField {
     }
     
 }
+
+extension NewStoreTextField {
+    
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        return false
+    }
+    
+    override func buildMenu(with builder: UIMenuBuilder) {
+        if #available(iOS 17.0, *) {
+            builder.remove(menu: .autoFill)
+        }
+        super.buildMenu(with: builder)
+    }
+    
+    override func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
+        return []
+    }
+    
+}

--- a/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
@@ -489,18 +489,6 @@ extension StoreUpdateRequestViewController: UIPickerViewDelegate, UIPickerViewDa
         }
     }
     
-//    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-//        switch row {
-//        case 1:
-//            typeTextField.text = "수정"
-//        case 2:
-//            typeTextField.text = "삭제"
-//        default:
-//            typeTextField.text = ""
-//        }
-//        viewModel.action(input: .completeButtonIsEnable(type: typeTextField.text ?? "", content: contentTextView.text ?? ""))
-//    }
-    
 }
 
 extension StoreUpdateRequestViewController: UITextFieldDelegate {

--- a/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
@@ -92,7 +92,19 @@ final class StoreUpdateRequestViewController: UIViewController {
         )
         selectButton.rx.tap
             .bind { [weak self] _ in
+                switch self?.typePickerView.selectedRow(inComponent: 0) {
+                case 1:
+                    textField.text = "수정"
+                case 2:
+                    textField.text = "삭제"
+                default:
+                    textField.text = ""
+                }
                 textField.endEditing(true)
+                self?.viewModel.action(input: .completeButtonIsEnable(
+                    type: self?.typeTextField.text ?? "",
+                    content: self?.contentTextView.text ?? ""
+                ))
             }
             .disposed(by: disposeBag)
         
@@ -477,17 +489,17 @@ extension StoreUpdateRequestViewController: UIPickerViewDelegate, UIPickerViewDa
         }
     }
     
-    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        switch row {
-        case 1:
-            typeTextField.text = "수정"
-        case 2:
-            typeTextField.text = "삭제"
-        default:
-            typeTextField.text = ""
-        }
-        viewModel.action(input: .completeButtonIsEnable(type: typeTextField.text ?? "", content: contentTextView.text ?? ""))
-    }
+//    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+//        switch row {
+//        case 1:
+//            typeTextField.text = "수정"
+//        case 2:
+//            typeTextField.text = "삭제"
+//        default:
+//            typeTextField.text = ""
+//        }
+//        viewModel.action(input: .completeButtonIsEnable(type: typeTextField.text ?? "", content: contentTextView.text ?? ""))
+//    }
     
 }
 


### PR DESCRIPTION
## ⭐️ Issue Number

- #278

## 🚩 Summary

- UITextField의 action 수정
- UItTextField drag 방지
- UITextField inputView의 UIPickerView에서 확인 버튼 binding 수정

![Simulator Screen Recording - iPhone 15 - 2024-02-19 at 04 22 33](https://github.com/Korea-Certified-Store/iOS/assets/128480641/63ac279f-5353-4925-8867-7fa7c9f7d644)

## 🛠️ Technical Concerns

### UITextField Action 방지

drag, copy, paste, autofill 등의 액션을 방지하여 UIPickerView 외의 입력을 방지했다.
사용자가 UITextField라는 것을 인지하지 못하도록 하기 위함이기도 하다.
영상에서는 수정 후가 제대로 보이지 않지만 드래그와 액션을 하기 위해 UITextField를 계속 선택하고 있다.

| 기존 | 수정후|
| - | - |
|![Simulator Screen Recording - iPhone 15 - 2024-02-19 at 04 25 35](https://github.com/Korea-Certified-Store/iOS/assets/128480641/7866780a-5cd2-4e2c-84b4-693618724a7f)|![Simulator Screen Recording - iPhone 15 - 2024-02-19 at 04 17 05](https://github.com/Korea-Certified-Store/iOS/assets/128480641/f578888c-3d52-45a0-858e-93401d46769f)|


### UIPickerView의 애니메이션과 확인버튼의 시간차

UIPickerView의 선택이 확정되기 전에 확인 버튼이 작동하면 WarningLabel을 활성화 시키는 현상이 있었다.
그래서 UIPickerView가 실시간으로 변경되는 것이 아니라 확인 버튼을 눌렀을 때만 변경되도록 수정했다.

| 기존 | 수정후|
| - | - |
|![Simulator Screen Recording - iPhone 15 - 2024-02-19 at 04 26 37](https://github.com/Korea-Certified-Store/iOS/assets/128480641/8a87111d-fc5e-4abb-9160-78c5e3fc9bae)|![Simulator Screen Recording - iPhone 15 - 2024-02-19 at 04 17 05](https://github.com/Korea-Certified-Store/iOS/assets/128480641/da6dd2f9-d4fc-45fe-904e-f1aa9cd89866)|

