### PR TITLE
모든 버튼 및 동작 로딩 중 다른 동작 방지

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -1597,7 +1597,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = MMM58CZBQF;
+				DEVELOPMENT_TEAM = 7CQAR4CYZX;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
@@ -1615,7 +1615,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.yeonghyeon.nainga;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.nainga;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1636,7 +1636,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MMM58CZBQF;
+				DEVELOPMENT_TEAM = 7CQAR4CYZX;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KCS/Resource/Info.plist;
@@ -1654,7 +1654,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.yeonghyeon.nainga;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kcs.nainga;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -688,7 +688,10 @@ private extension HomeViewController {
         marker.touchHandler = { [weak self] (_: NMFOverlay) -> Bool in
             self?.disableAllWhileLoading()
             if let clickedMarker = self?.clickedMarker {
-                if clickedMarker == marker { return true }
+                if clickedMarker == marker { 
+                    self?.enableAllWhileLoading()
+                    return true
+                }
                 self?.storeInformationViewDismiss(changeMarker: true)
             }
             

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -400,9 +400,9 @@ private extension HomeViewController {
                     storeListViewController.updateCountLabel(text: "총 \(stores.count)개의 가게가 있습니다")
                     storeListViewController.updateList(stores: stores)
                 }
-                safeFilterButton.isEnabled = true
-                exemplaryFilterButton.isEnabled = true
-                goodPriceFilterButton.isEnabled = true
+                safeFilterButton.isUserInteractionEnabled = true
+                exemplaryFilterButton.isUserInteractionEnabled = true
+                goodPriceFilterButton.isUserInteractionEnabled = true
             }
             .disposed(by: disposeBag)
     }
@@ -527,7 +527,7 @@ private extension HomeViewController {
                 viewModel.action(
                     input: .filterButtonTapped(activatedFilter: type)
                 )
-                button.isEnabled = false
+                button.isUserInteractionEnabled = false
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
@@ -586,9 +586,9 @@ private extension HomeViewController {
                 researchKeywordButton.isHidden = false
                 refreshButton.isHidden = true
                 moreStoreButton.isHidden = true
-                safeFilterButton.isEnabled = false
-                exemplaryFilterButton.isEnabled = false
-                goodPriceFilterButton.isEnabled = false
+                safeFilterButton.isUserInteractionEnabled = false
+                exemplaryFilterButton.isUserInteractionEnabled = false
+                goodPriceFilterButton.isUserInteractionEnabled = false
             }
             .disposed(by: disposeBag)
         
@@ -611,9 +611,9 @@ private extension HomeViewController {
                 }
                 mapView.mapView.positionMode = .normal
                 locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-                safeFilterButton.isEnabled = true
-                exemplaryFilterButton.isEnabled = true
-                goodPriceFilterButton.isEnabled = true
+                safeFilterButton.isUserInteractionEnabled = true
+                exemplaryFilterButton.isUserInteractionEnabled = true
+                goodPriceFilterButton.isUserInteractionEnabled = true
             }
             .disposed(by: disposeBag)
         
@@ -633,9 +633,9 @@ private extension HomeViewController {
                 mapView.mapView.moveCamera(cameraUpdate)
                 mapView.mapView.positionMode = .normal
                 locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-                safeFilterButton.isEnabled = true
-                exemplaryFilterButton.isEnabled = true
-                goodPriceFilterButton.isEnabled = true
+                safeFilterButton.isUserInteractionEnabled = true
+                exemplaryFilterButton.isUserInteractionEnabled = true
+                goodPriceFilterButton.isUserInteractionEnabled = true
                 
                 guard let marker = markers.first(where: { $0.tag == store.id}) else { return }
                 if let clickedMarker = clickedMarker {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -400,9 +400,6 @@ private extension HomeViewController {
                     storeListViewController.updateCountLabel(text: "총 \(stores.count)개의 가게가 있습니다")
                     storeListViewController.updateList(stores: stores)
                 }
-                safeFilterButton.isUserInteractionEnabled = true
-                exemplaryFilterButton.isUserInteractionEnabled = true
-                goodPriceFilterButton.isUserInteractionEnabled = true
             }
             .disposed(by: disposeBag)
     }
@@ -527,7 +524,6 @@ private extension HomeViewController {
                 viewModel.action(
                     input: .filterButtonTapped(activatedFilter: type)
                 )
-                button.isUserInteractionEnabled = false
                 return !lastState
             }
             .bind(to: button.rx.isSelected)
@@ -586,9 +582,6 @@ private extension HomeViewController {
                 researchKeywordButton.isHidden = false
                 refreshButton.isHidden = true
                 moreStoreButton.isHidden = true
-                safeFilterButton.isUserInteractionEnabled = false
-                exemplaryFilterButton.isUserInteractionEnabled = false
-                goodPriceFilterButton.isUserInteractionEnabled = false
             }
             .disposed(by: disposeBag)
         
@@ -611,9 +604,6 @@ private extension HomeViewController {
                 }
                 mapView.mapView.positionMode = .normal
                 locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-                safeFilterButton.isUserInteractionEnabled = true
-                exemplaryFilterButton.isUserInteractionEnabled = true
-                goodPriceFilterButton.isUserInteractionEnabled = true
             }
             .disposed(by: disposeBag)
         
@@ -633,9 +623,6 @@ private extension HomeViewController {
                 mapView.mapView.moveCamera(cameraUpdate)
                 mapView.mapView.positionMode = .normal
                 locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-                safeFilterButton.isUserInteractionEnabled = true
-                exemplaryFilterButton.isUserInteractionEnabled = true
-                goodPriceFilterButton.isUserInteractionEnabled = true
                 
                 guard let marker = markers.first(where: { $0.tag == store.id}) else { return }
                 if let clickedMarker = clickedMarker {
@@ -980,6 +967,30 @@ extension HomeViewController: NMFMapViewCameraDelegate {
             )
         }
         .disposed(by: disposeBag)
+    }
+    
+    func disableAllWhileLoading() {
+        goodPriceFilterButton.isUserInteractionEnabled = false
+        exemplaryFilterButton.isUserInteractionEnabled = false
+        safeFilterButton.isUserInteractionEnabled = false
+        searchBarView.isUserInteractionEnabled = false
+        mapView.isUserInteractionEnabled = false
+        refreshButton.isUserInteractionEnabled = false
+        moreStoreButton.isUserInteractionEnabled = false
+        researchKeywordButton.isUserInteractionEnabled = false
+        backStoreListButton.isUserInteractionEnabled = false
+    }
+    
+    func enableAllWhileLoading() {
+        goodPriceFilterButton.isUserInteractionEnabled = true
+        exemplaryFilterButton.isUserInteractionEnabled = true
+        safeFilterButton.isUserInteractionEnabled = true
+        searchBarView.isUserInteractionEnabled = true
+        mapView.isUserInteractionEnabled = true
+        refreshButton.isUserInteractionEnabled = true
+        moreStoreButton.isUserInteractionEnabled = true
+        researchKeywordButton.isUserInteractionEnabled = true
+        backStoreListButton.isUserInteractionEnabled = true
     }
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #285

## 🚩 Summary

- 모든 사용자 동시 동작 불가능하도록 설정

## 🛠️ Technical Concerns

### 사용자의 동시 동작을 막는 이유

사용자가 특정 동작과 다른 동작을 동시에 진행하는 경우 UIViewController를 present 및 dismiss하는 플로우가 꼬이는 현상이 발생했다.
특히 UIViewController를 dismiss와 present를 순차적으로 하는 동작을 중복으로 하는 경우 Crash가 발생하여 앱이 종료되는 현상이 발생했다.
이를 방지하고자 사용자가 특정 동작을 진행하면 해당 동작의 결과가 나타날 때까지 모든 사용자 동작을 차단했다.

### NmapsMap의 한계 해결

NMapsMap은 map을 tap했을 때, marker를 tap했을 때 handler를 각각 함수 혹은 함수 대입으로 제공한다.
하지만 RxSwift나 UITapGestureRecognizer와 같이 즉각적인 반응이 아니라 내부적으로 어떤 로직을 거쳐서 진행되기 때문에 사용자의 동작과 handler 혹은 함수의 실행 사이에 시간 공백이 존재했다.
이 시간 공백 사이에 사용자가 다른 동작을 실행한다면 다시 Crash가 발생하거나 예상하지 못하는 플로우가 발생한다.
NMapsMap의 내부 코드를 수정할 수 없고, Marker와 Map이 UIKit에 존재하는 요소가 아니기 때문에 RxSwift로 binding 할 수 없었다.

이를 해결하기 위해서 RxSwift의 다른 모든 요소에 debounce를 적용하여 해결했다.
다른 모든 사용자 동작 요소에 debounce를 사용하여 Marker가 Tap되거나 Map이 Tap되는 것을 인식하는 순간보다 후에 동작을 인식하도록 했다.
그러면 isUserInteraction이 false인지 확인하여 현재 동작이 disable 되어있는 상태에서 동작을 실행했는지 확인하여 NMapsMap의 한계를 극복했다.

## 🙂 To Reviwer

- 제공하는 SDK의 한계를 극복했습니다... 모르는 부분은 꼭 질문 남겨주세요.
- debounce 값은 임시로 500 밀리초로 잡아놨습니다. 

## 📋 To Do

- debounce 값 수정
