### PR TITLE
뒤로가기 버튼 크기 수정

### DIFF
--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -259,13 +259,13 @@ private extension SearchViewController {
         NSLayoutConstraint.activate([
             backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
             backButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            backButton.widthAnchor.constraint(equalToConstant: 10),
-            backButton.heightAnchor.constraint(equalToConstant: 16)
+            backButton.widthAnchor.constraint(equalToConstant: 13),
+            backButton.heightAnchor.constraint(equalToConstant: 24)
         ])
         
         NSLayoutConstraint.activate([
             searchBarView.centerYAnchor.constraint(equalTo: backButton.centerYAnchor),
-            searchBarView.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 16),
+            searchBarView.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: 13),
             searchBarView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
             searchBarView.heightAnchor.constraint(equalToConstant: 50)
         ])

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -244,6 +244,7 @@ private extension SearchViewController {
     func setup() {
         view.backgroundColor = .white
         modalPresentationStyle = .fullScreen
+        modalTransitionStyle = .crossDissolve
     }
     
     func addUIComponents() {


### PR DESCRIPTION
## ⭐️ Issue Number

- #296 

## 🚩 Summary

- SearchViewController의 뒤로가기 버튼 크기를 수정한다
- SearchViewController의 TransitionStyle을 적용한다

![Simulator Screen Recording - iPhone 15 - 2024-02-21 at 14 30 27](https://github.com/Korea-Certified-Store/iOS/assets/62226667/ab37e1e7-686d-4762-9632-8ee96d2d03d1)

