### PR TITLE
refreshCameraPositionObserver 중복 바인딩 수정

### DIFF
--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -64,7 +64,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let searchObserver = PublishRelay<String>()
         let textObserver = PublishRelay<String>()
         let addressObserver = PublishRelay<String>()
-        let refreshCameraPositionObserver = BehaviorRelay<NMFCameraPosition>(value: NMFCameraPosition())
+        let refreshCameraPositionObserver = PublishRelay<NMFCameraPosition>()
+        let endMoveCameraPositionObserver = PublishRelay<NMFCameraPosition>()
         let searchKeywordRepository = SearchKeywordRepositoryImpl(
             userDefaults: UserDefaults()
         )
@@ -130,7 +131,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             summaryViewHeightObserver: summaryViewHeightObserver,
             listCellSelectedObserver: listCellSelectedObserver,
             searchObserver: searchObserver, 
-            refreshCameraPositionObserver: refreshCameraPositionObserver
+            refreshCameraPositionObserver: refreshCameraPositionObserver,
+            endMoveCameraPositionObserver: endMoveCameraPositionObserver
         )
         
         var rootViewController: UIViewController


### PR DESCRIPTION
## ⭐️ Issue Number

- #303 

## 🚩 Summary

- refreshCameraPositionObserver의 중복 바인딩을 수정한다

## 🛠️ Technical Concerns

### CombineLatest

카메라의 이동이 시작하는 순간 refreshCameraPosition에서 accept를 하고 카메라 이동이 끝난 시점에 endMoveCameraPosition을 accept한다. 이 두 옵저버들을 CombineLatest를 통해 묶어주어 두 옵저버 모두에게서 반응이 왔을 때, 두 좌표의 차이를 이용하여 카메라 이동이 얼마나 되었는지를 확인하였다.

```swift
Observable.combineLatest(refreshCameraPositionObserver, endMoveCameraPositionObserver)
    .observe(on: MainScheduler())
    .bind { [weak self] refreshCameraPosition, endMoveCameraPosition in
        guard let self = self else { return }
        viewModel.action(
            input: .compareCameraPosition(
                refreshCameraPosition: refreshCameraPosition,
                endMoveCameraPosition: endMoveCameraPosition,
                refreshCameraPoint: mapView.mapView.projection.point(from: refreshCameraPosition.target),
                endMoveCameraPoint: mapView.mapView.projection.point(from: endMoveCameraPosition.target)
            )
        )
    }
    .disposed(by: disposeBag)
```
