### PR TITLE
앱 반응속도 개선 [Pair Programming]

### DIFF
--- a/KCS/KCS/Presentation/OnBoarding/OnboardingViewController.swift
+++ b/KCS/KCS/Presentation/OnBoarding/OnboardingViewController.swift
@@ -63,7 +63,7 @@ final class OnboardingViewController: UIViewController {
         button.backgroundColor = .primary1
         button.isHidden = true
         button.rx.tap
-            .debounce(.milliseconds(100), scheduler: MainScheduler())
+            .throttle(.milliseconds(10), latest: false, scheduler: MainScheduler())
             .bind { [weak self] in
                 guard let self = self else { return }
                 UserDefaults.standard.set(false, forKey: "executeOnboarding")

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -244,7 +244,6 @@ private extension SearchViewController {
     func setup() {
         view.backgroundColor = .white
         modalPresentationStyle = .fullScreen
-        modalTransitionStyle = .crossDissolve
     }
     
     func addUIComponents() {

--- a/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
@@ -72,7 +72,7 @@ extension StoreInformationViewController {
     
     func bind() {
         viewModel.errorAlertOutput
-            .debounce(.milliseconds(100), scheduler: MainScheduler())
+            .throttle(.milliseconds(10), latest: false, scheduler: MainScheduler())
             .bind { [weak self] error in
                 self?.presentErrorAlert(error: error)
             }
@@ -86,7 +86,7 @@ extension StoreInformationViewController {
             .disposed(by: disposeBag)
         
         viewModel.summaryCallButtonOutput
-            .debounce(.milliseconds(100), scheduler: MainScheduler())
+            .throttle(.milliseconds(10), latest: false, scheduler: MainScheduler())
             .bind { [weak self] phoneNumber in
                 self?.summaryView.setCallButton(phoneNumber: phoneNumber)
             }

--- a/KCS/KCS/Presentation/StoreInformation/View/SummaryView.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/SummaryView.swift
@@ -196,7 +196,7 @@ extension SummaryView {
     func setCallButton(phoneNumber: String) {
         storeCallButton.isHidden = false
         callDisposable = storeCallButton.rx.tap
-            .debounce(.milliseconds(100), scheduler: MainScheduler())
+            .throttle(.milliseconds(10), latest: false, scheduler: MainScheduler())
             .bind { [weak self] _ in
                 self?.callButtonTapped(phoneNum: phoneNumber)
             }


### PR DESCRIPTION
## ⭐️ Issue Number

- #309

## 🚩 Summary

- 앱 반응속도 개선

## 🛠️ Technical Concerns

### debounce vs throttle

모든 사용자 동작을 debounce로 처리하여 사용자의 동시동작을 방지했다. 
하지만 debounce의 경우 정해진 시간동안 앱의 반응이 지연되는 크리티컬한 UX 저하가 있었다.
그래서 throttle을 사용하여 첫 동작에 반응하고 이후 시간동안 동작을 방지하는 방법으로 개선했다.

- 개선전
```swift
.debounce(.milliseconds(100), scheduler: MainScheduler())
```
- 개선후
```swift
.throttle(.milliseconds(10), latest: false, scheduler: MainScheduler())
```

### map didTap, marker touchHandler의 한계 극복

NMapsMap SDK는 map didTap과 marker의 touchHandler를 제공한다.
하지만 마커를 선택하고 맵을 선택하는 것과 실제 didTap과 touchHandler가 작동하는 그 사이에 약간의 시간 텀이 존재했다.
그래서 didTap과 touchHandler에서 동시 동작을 방지하더라도 시간 텀으로 인한 오류가 발생했다.
이를 해결하고자 모든 동작에 didTap과 touchHandler가 실행되는 시간을 대략적으로 측정하여 모든 사용자 동작에 대한 반응을 지연시켜서 해결했었다.
이로 인해 앱의 반응속도가 특정 기간동안 계속하여 지연되는 현상이 발생했다.
이를 didTap과 touchHanlder에서 현재 동시동작이 disable인지 enable인지 확인하는 것으로 해결했다.
