### PR TITLE
GetOpenClosedUseCase Date() 주입 리팩토링

### DIFF
--- a/KCS/KCS/Domain/Entity/OpenClosedType.swift
+++ b/KCS/KCS/Domain/Entity/OpenClosedType.swift
@@ -12,8 +12,9 @@ enum OpenClosedType: String {
     case open = "영업 중"
     case closed = "영업 종료"
     case breakTime = "브레이크 타임"
-    case dayOff, none = ""
+    case dayOff = "휴무일"
     case alwaysOpen = "24시간 영업"
+    case none = ""
     
     var description: String {
         switch self {
@@ -24,9 +25,9 @@ enum OpenClosedType: String {
         case .breakTime:
             return OpenClosedType.breakTime.rawValue
         case .dayOff:
-            return "휴무일"
+            return OpenClosedType.dayOff.rawValue
         case .none:
-            return ""
+            return OpenClosedType.none.rawValue
         }
     }
     

--- a/KCS/KCS/Domain/UseCase/protocol/GetOpenClosedUseCase.swift
+++ b/KCS/KCS/Domain/UseCase/protocol/GetOpenClosedUseCase.swift
@@ -10,7 +10,8 @@ import Foundation
 protocol GetOpenClosedUseCase {
     
     func execute(
-        openingHours: [RegularOpeningHours]
+        openingHours: [RegularOpeningHours],
+        today: Date
     ) throws -> OpenClosedContent
     
 }

--- a/KCS/KCS/Presentation/StoreInformation/ViewModel/StoreInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreInformation/ViewModel/StoreInformationViewModelImpl.swift
@@ -43,7 +43,7 @@ private extension StoreInformationViewModelImpl {
         }
         
         do {
-            let openClosedContent = try dependency.getOpenClosedUseCase.execute(openingHours: store.openingHour)
+            let openClosedContent = try dependency.getOpenClosedUseCase.execute(openingHours: store.openingHour, today: Date())
             setSummaryUIContentsOutput.accept(
                 SummaryViewContents(
                     storeTitle: store.title,


### PR DESCRIPTION
## ⭐️ Issue Number

- #316 

## 🚩 Summary

- `GetOpenClosedUseCase`에서 사용되는 `Date()`를 외부에서 주입받도록 리팩토링을 진행한다
- 가게 상세 정보 View에서 휴무일이 dayOff로 표기되는 오류를 수정한다

## 🛠️ Technical Concerns

### Date() 주입

Clean Architecture에 의하면 Domain Layer는 비즈니스 로직이나 Entity만을 소유하고 있어야한다. 
외부에서 가져와야하는 모든 데이터는 밖에서 주입을 받아야 했는데, 수정 전 `GetOpenClosedUseCase`는 현재 시간을 나타내는 `Date()`를 UseCase 로직 내부에 직접 가지고있었다. 
이렇게 되면 테스트 코드를 작성하는데에 어려움이 생길 뿐만 아니라 현재 시간을 나타내는 데이터는 비즈니스 로직과 Entity만을 소유하는 Domain Layer에 들어가서는 안되는 값이기 때문에 Clean Architecture에서 어긋난다고 판단이 되었다.
따라서 `Date()`를 외부 즉, Presentation Layer에서 주입받도록 로직을 수정하도록 리팩토링을 진행하였다.
