### PR TITLE
HomeViewModel SRP 적용

### DIFF
--- a/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
@@ -39,17 +39,17 @@ final class FetchStoresRepositoryImpl: FetchStoresRepository {
                         self?.storeStorage.stores = resultStores.flatMap({ $0 })
                         if isEntire {
                             observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(),
+                                fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
                                 stores: resultStores.flatMap { $0 }
                             ))
                         } else if let firstIndexStore = resultStores.first {
                             observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count),
+                                fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count, fetchCount: 1),
                                 stores: firstIndexStore
                             ))
                         } else {
                             observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(),
+                                fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
                                 stores: []
                             ))
                         }

--- a/KCS/KCS/Domain/Entity/FetchStores.swift
+++ b/KCS/KCS/Domain/Entity/FetchStores.swift
@@ -16,7 +16,7 @@ struct FetchStores {
 
 struct FetchCountContent {
     
-    var maxFetchCount: Int = 1
-    var fetchCount: Int = 1
+    var maxFetchCount: Int
+    var fetchCount: Int
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -50,18 +50,14 @@ final class HomeViewModelImpl: HomeViewModel {
             filterButtonTapped(filter: filter)
         case .markerTapped(let tag):
             markerTapped(tag: tag)
-        case .locationButtonTapped(let locationAuthorizationStatus, let positionMode):
-            locationButtonTapped(locationAuthorizationStatus: locationAuthorizationStatus, positionMode: positionMode)
-        case .dimViewTapGestureEnded:
-            dimViewTapGestureEnded()
         case .setMarker(let store, let certificationType):
             setMarker(store: store, certificationType: certificationType)
+        case .locationButtonTapped(let locationAuthorizationStatus, let positionMode):
+            locationButtonTapped(locationAuthorizationStatus: locationAuthorizationStatus, positionMode: positionMode)
         case .checkLocationAuthorization(let status):
             checkLocationAuthorization(status: status)
         case .search(let location, let keyword):
             search(location: location, keyword: keyword)
-        case .resetFilters:
-            resetFilters()
         case .compareCameraPosition(let refreshCameraPosition, let endMoveCameraPosition, let refreshCameraPoint, let endMoveCameraPoint):
             compareCameraPosition(
                 refreshCameraPosition: refreshCameraPosition,
@@ -69,6 +65,10 @@ final class HomeViewModelImpl: HomeViewModel {
                 refreshCameraPoint: refreshCameraPoint,
                 endMoveCameraPoint: endMoveCameraPoint
             )
+        case .resetFilters:
+            resetFilters()
+        case .dimViewTapGestureEnded:
+            dimViewTapGestureEnded()
         }
     }
     
@@ -179,10 +179,6 @@ private extension HomeViewModelImpl {
         default:
             break
         }
-    }
-    
-    func dimViewTapGestureEnded() {
-        dimViewTapGestureEndedOutput.accept(())
     }
     
     func checkLocationAuthorization(status: CLAuthorizationStatus) {

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -20,18 +20,18 @@ enum HomeViewModelInputCase {
     case moreStoreButtonTapped
     case filterButtonTapped(activatedFilter: CertificationType)
     case markerTapped(tag: UInt)
-    case locationButtonTapped(locationAuthorizationStatus: CLAuthorizationStatus, positionMode: NMFMyPositionMode)
-    case dimViewTapGestureEnded
     case setMarker(store: Store, certificationType: CertificationType)
+    case locationButtonTapped(locationAuthorizationStatus: CLAuthorizationStatus, positionMode: NMFMyPositionMode)
     case checkLocationAuthorization(status: CLAuthorizationStatus)
     case search(location: Location, keyword: String)
-    case resetFilters
     case compareCameraPosition(
         refreshCameraPosition: NMFCameraPosition,
         endMoveCameraPosition: NMFCameraPosition,
         refreshCameraPoint: CGPoint,
         endMoveCameraPoint: CGPoint
     )
+    case resetFilters
+    case dimViewTapGestureEnded
     
 }
 


### PR DESCRIPTION
## ⭐️ Issue Number

- #328 

## 🚩 Summary

- `HomeViewModel` 내부에서만 사용되는 함수에 private을 적용시킨다.
- `HomeViewModel` 내부 `fetchCount`와 `maxCount` 객체를 `FetchContent` 객체 하나로 변경한다.

## 🙂 To Reviwer

- SRP를 적용시킨다는 의미가 `HomeViewModel`에서는 조금 모호한 것 같습니다. `HomeViewController`에서 들어오는 input에 따라 로직을 적용시켜 `HomeViewController`를 변화시킨다는 관점에서 봤을 땐, 현재 `HomeViewModel`에 존재하는 함수들을 class별로 분리하여 사용하는 것은 옳지 않다고 판단이 됩니다. 이에 대해서 어떻게 생각하시는지 리뷰로 남겨주시고 추후에 다시 상의해보면 좋을 것 같습니다.
