### PR TITLE
ViewController 로직 ViewModel로 이동

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -515,8 +515,8 @@
 		59503A6D2B7FB2EB0006CF35 /* NewStoreRequest */ = {
 			isa = PBXGroup;
 			children = (
-				59503A732B80A2890006CF35 /* ViewModel */,
 				59503A6E2B7FB2FE0006CF35 /* View */,
+				59503A732B80A2890006CF35 /* ViewModel */,
 			);
 			path = NewStoreRequest;
 			sourceTree = "<group>";
@@ -552,8 +552,8 @@
 		59503A792B80E8260006CF35 /* StoreUpdateRequest */ = {
 			isa = PBXGroup;
 			children = (
-				59503A7D2B80ED160006CF35 /* ViewModel */,
 				59503A7A2B80E84A0006CF35 /* View */,
+				59503A7D2B80ED160006CF35 /* ViewModel */,
 			);
 			path = StoreUpdateRequest;
 			sourceTree = "<group>";

--- a/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
@@ -16,7 +16,7 @@ final class PostNewStoreRepositoryImpl: PostNewStoreRepository {
                 newStoreRequestDTO: NewStoreRequestDTO(
                     storeName: storeName,
                     formattedAddress: formattedAddress,
-                    certifications: certifications.map{ $0.rawValue }
+                    certifications: certifications.map { $0.rawValue }
                 )
             ))
             .response { response in

--- a/KCS/KCS/Domain/Entity/DetailViewContents.swift
+++ b/KCS/KCS/Domain/Entity/DetailViewContents.swift
@@ -14,7 +14,6 @@ struct DetailViewContents {
     let certificationTypes: [CertificationType]
     let address: String
     let phoneNumber: String
-    let openClosedContent: OpenClosedContent
     let detailOpeningHour: [DetailOpeningHour]
     
 }

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -761,7 +761,6 @@ private extension HomeViewController {
     
     func markerTouchHandler(marker: Marker) {
         marker.touchHandler = { [weak self] (_: NMFOverlay) -> Bool in
-            // TODO: enable 확인
             if self?.mapView.isUserInteractionEnabled == true {
                 self?.disableAllWhileLoading()
                 if let clickedMarker = self?.clickedMarker {
@@ -904,6 +903,11 @@ private extension HomeViewController {
     }
     
     func configureConstraints() {
+        viewConstraints()
+        buttonConstraints()
+    }
+    
+    func viewConstraints() {
         NSLayoutConstraint.activate([
             mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
             mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
@@ -919,13 +923,6 @@ private extension HomeViewController {
         ])
         
         NSLayoutConstraint.activate([
-            locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            locationButton.widthAnchor.constraint(equalToConstant: 48),
-            locationButton.heightAnchor.constraint(equalToConstant: 48),
-            locationButtonBottomConstraint
-        ])
-        
-        NSLayoutConstraint.activate([
             searchBarView.topAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.topAnchor, constant: 8),
             searchBarView.trailingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.trailingAnchor, constant: -16),
             searchBarView.heightAnchor.constraint(equalToConstant: 50),
@@ -935,6 +932,15 @@ private extension HomeViewController {
         NSLayoutConstraint.activate([
             filterButtonStackView.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             filterButtonStackView.topAnchor.constraint(equalTo: searchBarView.bottomAnchor, constant: 8)
+        ])
+    }
+    
+    func buttonConstraints() {
+        NSLayoutConstraint.activate([
+            locationButton.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            locationButton.widthAnchor.constraint(equalToConstant: 48),
+            locationButton.heightAnchor.constraint(equalToConstant: 48),
+            locationButtonBottomConstraint
         ])
         
         NSLayoutConstraint.activate([

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -401,6 +401,7 @@ private extension HomeViewController {
         bindSearchResult()
         bindMoreStoreButton()
         bindRefreshCameraPosition()
+        bindMapViewChanged()
     }
     
     func bindFetchStores() {
@@ -765,6 +766,14 @@ private extension HomeViewController {
             .disposed(by: disposeBag)
     }
     
+    func bindMapViewChanged() {
+        viewModel.mapViewChangedByGesture
+            .bind { [weak self] in
+                self?.locationButton.setImage(UIImage.locationButtonNone, for: .normal)
+            }
+            .disposed(by: disposeBag)
+    }
+    
 }
 
 private extension HomeViewController {
@@ -1108,9 +1117,7 @@ extension HomeViewController: CLLocationManagerDelegate {
 extension HomeViewController: NMFMapViewCameraDelegate {
     
     func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
-        if reason == NMFMapChangedByGesture {
-            locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-        }
+        viewModel.action(input: .mapViewChanged(reason: reason))
     }
     
     func mapViewCameraIdle(_ mapView: NMFMapView) {

--- a/KCS/KCS/Presentation/Home/View/HomeViewController.swift
+++ b/KCS/KCS/Presentation/Home/View/HomeViewController.swift
@@ -1061,33 +1061,6 @@ private extension HomeViewController {
         toastView.removeFromSuperviewWithAnimation()
     }
     
-}
-
-extension HomeViewController: CLLocationManagerDelegate {
-    
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        viewModel.action(
-            input: .checkLocationAuthorization(
-                status: locationManager.authorizationStatus
-            )
-        )
-    }
-    
-}
-
-extension HomeViewController: NMFMapViewCameraDelegate {
-    
-    func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
-        if reason == NMFMapChangedByGesture {
-            locationButton.setImage(UIImage.locationButtonNone, for: .normal)
-        }
-    }
-    
-    func mapViewCameraIdle(_ mapView: NMFMapView) {
-        endMoveCameraPositionObserver.accept(mapView.cameraPosition)
-        enableAllWhileLoading()
-    }
-    
     func disableAllWhileLoading() {
         goodPriceFilterButton.isUserInteractionEnabled = false
         exemplaryFilterButton.isUserInteractionEnabled = false
@@ -1116,6 +1089,33 @@ extension HomeViewController: NMFMapViewCameraDelegate {
         researchKeywordButton.isUserInteractionEnabled = true
         backStoreListButton.isUserInteractionEnabled = true
         addStoreButton.isUserInteractionEnabled = true
+    }
+    
+}
+
+extension HomeViewController: CLLocationManagerDelegate {
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        viewModel.action(
+            input: .checkLocationAuthorization(
+                status: locationManager.authorizationStatus
+            )
+        )
+    }
+    
+}
+
+extension HomeViewController: NMFMapViewCameraDelegate {
+    
+    func mapView(_ mapView: NMFMapView, cameraWillChangeByReason reason: Int, animated: Bool) {
+        if reason == NMFMapChangedByGesture {
+            locationButton.setImage(UIImage.locationButtonNone, for: .normal)
+        }
+    }
+    
+    func mapViewCameraIdle(_ mapView: NMFMapView) {
+        endMoveCameraPositionObserver.accept(mapView.cameraPosition)
+        enableAllWhileLoading()
     }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -29,6 +29,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let dimViewTapGestureEndedOutput = PublishRelay<Void>()
     let searchStoresOutput = PublishRelay<[Store]>()
     let searchOneStoreOutput = PublishRelay<Store>()
+    let noSearchStoreOutput = PublishRelay<Void>()
     let moreStoreButtonHiddenOutput = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
@@ -194,12 +195,16 @@ private extension HomeViewModelImpl {
             .execute(location: location, keyword: keyword)
             .subscribe(onNext: { [weak self] stores in
                 guard let self = self else { return }
-                fetchContent.fetchCount = stores.count
-                if stores.count == 1 {
-                    guard let oneStore = stores.first else { return }
-                    searchOneStoreOutput.accept(oneStore)
+                if stores.isEmpty {
+                    noSearchStoreOutput.accept(())
                 } else {
-                    searchStoresOutput.accept(stores)
+                    fetchContent.fetchCount = stores.count
+                    if stores.count == 1 {
+                        guard let oneStore = stores.first else { return }
+                        searchOneStoreOutput.accept(oneStore)
+                    } else {
+                        searchStoresOutput.accept(stores)
+                    }
                 }
             }, onError: { [weak self] error in
                 if let alertError = error as? ErrorAlertMessage {

--- a/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/HomeViewModelImpl.swift
@@ -32,6 +32,7 @@ final class HomeViewModelImpl: HomeViewModel {
     let searchOneStoreOutput = PublishRelay<Store>()
     let noSearchStoreOutput = PublishRelay<Void>()
     let moreStoreButtonHiddenOutput = PublishRelay<Void>()
+    let mapViewChangedByGesture = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     private var activatedFilter: [CertificationType] = []
@@ -70,6 +71,8 @@ final class HomeViewModelImpl: HomeViewModel {
             resetFilters()
         case .dimViewTapGestureEnded:
             dimViewTapGestureEnded()
+        case .mapViewChanged(let reason):
+            mapViewChanged(reason: reason)
         }
     }
     
@@ -247,6 +250,12 @@ private extension HomeViewModelImpl {
     
     func dimViewTapGestureEnded() {
         dimViewTapGestureEndedOutput.accept(())
+    }
+    
+    func mapViewChanged(reason: Int) {
+        if reason == NMFMapChangedByGesture {
+            mapViewChangedByGesture.accept(())
+        }
     }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -32,6 +32,7 @@ enum HomeViewModelInputCase {
     )
     case resetFilters
     case dimViewTapGestureEnded
+    case mapViewChanged(reason: Int)
     
 }
 
@@ -61,5 +62,6 @@ protocol HomeViewModelOutput {
     var searchOneStoreOutput: PublishRelay<Store> { get }
     var noSearchStoreOutput: PublishRelay<Void> { get }
     var moreStoreButtonHiddenOutput: PublishRelay<Void> { get }
+    var mapViewChangedByGesture: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -58,6 +58,7 @@ protocol HomeViewModelOutput {
     var dimViewTapGestureEndedOutput: PublishRelay<Void> { get }
     var searchStoresOutput: PublishRelay<[Store]> { get }
     var searchOneStoreOutput: PublishRelay<Store> { get }
+    var noSearchStoreOutput: PublishRelay<Void> { get }
     var moreStoreButtonHiddenOutput: PublishRelay<Void> { get }
     
 }

--- a/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
+++ b/KCS/KCS/Presentation/Home/ViewModel/protocol/HomeViewModel.swift
@@ -46,6 +46,7 @@ protocol HomeViewModelOutput {
     var getStoreInformationOutput: PublishRelay<Store> { get }
     var refreshDoneOutput: PublishRelay<Bool> { get }
     var filteredStoresOutput: PublishRelay<[FilteredStores]> { get }
+    var noFilteredStoreOutput: PublishRelay<Void> { get }
     var locationButtonOutput: PublishRelay<NMFMyPositionMode> { get }
     var setMarkerOutput: PublishRelay<MarkerContents> { get }
     var locationAuthorizationStatusDeniedOutput: PublishRelay<Void> { get }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -303,6 +303,12 @@ private extension SearchViewController {
     }
     
     func bind() {
+        bindRecentHistory()
+        bindAutoCompletion()
+        bindSearch()
+    }
+    
+    func bindRecentHistory() {
         viewModel.recentSearchKeywordsOutput
             .bind { [weak self] keywords in
                 guard let self = self else { return }
@@ -317,6 +323,15 @@ private extension SearchViewController {
             }
             .disposed(by: disposeBag)
         
+        viewModel.noRecentHistoryOutput
+            .bind { [weak self] in
+                guard let self = self else { return }
+                noHistoryView.isHidden = false
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    func bindAutoCompletion() {
         viewModel.autoCompleteKeywordsOutput
             .bind { [weak self] keywords in
                 guard let self = self else { return }
@@ -336,7 +351,9 @@ private extension SearchViewController {
                 self?.textObserver.accept(text)
             }
             .disposed(by: disposeBag)
-        
+    }
+    
+    func bindSearch() {
         viewModel.searchOutput
             .bind { [weak self] keyword in
                 self?.search(text: keyword)
@@ -346,13 +363,6 @@ private extension SearchViewController {
         viewModel.noKeywordToastOutput
             .bind { [weak self] _ in
                 self?.showToast(message: "검색어를 입력하세요.")
-            }
-            .disposed(by: disposeBag)
-        
-        viewModel.noRecentHistoryOutput
-            .bind { [weak self] in
-                guard let self = self else { return }
-                noHistoryView.isHidden = false
             }
             .disposed(by: disposeBag)
         

--- a/KCS/KCS/Presentation/StoreInformation/View/DetailView.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/DetailView.swift
@@ -301,22 +301,6 @@ private extension DetailView {
         ])
     }
     
-    func setOpeningHourText(openClosedContent: OpenClosedContent) {
-        if openClosedContent.openClosedType == .none {
-            storeOpenClosed.text = "영업시간 정보 없음"
-            storeOpenClosed.textColor = .black
-            openingHour.text = openClosedContent.openClosedType.rawValue
-            addressConstraint.constant = -174
-            phoneNumberConstraint.constant = 20 - 11
-        } else {
-            storeOpenClosed.text = openClosedContent.openClosedType.description
-            storeOpenClosed.textColor = UIColor.goodPrice
-            openingHour.text = openClosedContent.nextOpeningHour
-            addressConstraint.constant = -16
-            phoneNumberConstraint.constant = 20
-        }
-    }
-    
 }
 
 extension DetailView {
@@ -333,7 +317,6 @@ extension DetailView {
             }
         address.text = contents.address
         phoneNumber.text = contents.phoneNumber
-        setOpeningHourText(openClosedContent: contents.openClosedContent)
         
         var detailOpeningHours = contents.detailOpeningHour
         if detailOpeningHours.isEmpty { return }
@@ -357,6 +340,22 @@ extension DetailView {
     
     func setThumbnailImage(imageData: Data) {
         storeImageView.image = UIImage(data: imageData)
+    }
+    
+    func setOpeningHour(openClosedContent: OpenClosedContent) {
+        storeOpenClosed.text = openClosedContent.openClosedType.description
+        storeOpenClosed.textColor = UIColor.goodPrice
+        openingHour.text = openClosedContent.nextOpeningHour
+        addressConstraint.constant = -16
+        phoneNumberConstraint.constant = 20
+    }
+    
+    func setNoOpeningHour() {
+        storeOpenClosed.text = "영업시간 정보 없음"
+        storeOpenClosed.textColor = .black
+        openingHour.text = OpenClosedType.none.rawValue
+        addressConstraint.constant = -174
+        phoneNumberConstraint.constant = 20 - 11
     }
     
     func resetUIContents() {

--- a/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
+++ b/KCS/KCS/Presentation/StoreInformation/View/StoreInformationViewController.swift
@@ -104,6 +104,18 @@ extension StoreInformationViewController {
             }
             .disposed(by: disposeBag)
         
+        viewModel.openClosedContentOutput
+            .bind { [weak self] openClosedContent in
+                self?.detailView.setOpeningHour(openClosedContent: openClosedContent)
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.noneOpenClosedContentOutput
+            .bind { [weak self] in
+                self?.detailView.setNoOpeningHour()
+            }
+            .disposed(by: disposeBag)
+        
         updateReqeustButtonObserver
             .bind { [weak self] _ in
                 guard let self = self else { return }

--- a/KCS/KCS/Presentation/StoreInformation/ViewModel/Protocol/StoreInformationViewModel.swift
+++ b/KCS/KCS/Presentation/StoreInformation/ViewModel/Protocol/StoreInformationViewModel.swift
@@ -28,6 +28,8 @@ protocol StoreInformationViewModelInput {
 protocol StoreInformationViewModelOutput {
     
     var setDetailUIContentsOutput: PublishRelay<DetailViewContents> { get }
+    var openClosedContentOutput: PublishRelay<OpenClosedContent> { get }
+    var noneOpenClosedContentOutput: PublishRelay<Void> { get }
     var setSummaryUIContentsOutput: PublishRelay<SummaryViewContents> { get }
     var thumbnailImageOutput: PublishRelay<Data> { get }
     var summaryCallButtonOutput: PublishRelay<String> { get }

--- a/KCS/KCS/Presentation/StoreInformation/ViewModel/StoreInformationViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreInformation/ViewModel/StoreInformationViewModelImpl.swift
@@ -13,6 +13,8 @@ final class StoreInformationViewModelImpl: StoreInformationViewModel {
     let dependency: StoreInformationDependency
     
     let setDetailUIContentsOutput = PublishRelay<DetailViewContents>()
+    let openClosedContentOutput = PublishRelay<OpenClosedContent>()
+    let noneOpenClosedContentOutput = PublishRelay<Void>()
     let setSummaryUIContentsOutput = PublishRelay<SummaryViewContents>()
     let thumbnailImageOutput = PublishRelay<Data>()
     let summaryCallButtonOutput = PublishRelay<String>()
@@ -59,10 +61,14 @@ private extension StoreInformationViewModelImpl {
                     certificationTypes: store.certificationTypes,
                     address: store.address,
                     phoneNumber: store.phoneNumber ?? "전화번호 정보 없음",
-                    openClosedContent: openClosedContent,
                     detailOpeningHour: detailOpeningHour(openingHours: store.openingHour)
                 )
             )
+            if openClosedContent.openClosedType == .none {
+                noneOpenClosedContentOutput.accept(())
+            } else {
+                openClosedContentOutput.accept(openClosedContent)
+            }
         } catch {
             errorAlertOutput.accept(.client)
         }

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -108,7 +108,7 @@ private extension StoreUpdateRequestViewModelImpl {
                 self?.completeRequestOutput.accept(())
             },
             onError: { [weak self] error in
-                if let error = error as? ErrorAlertMessage{
+                if let error = error as? ErrorAlertMessage {
                     self?.errorAlertOutput.accept(error)
                 } else {
                     self?.errorAlertOutput.accept(.client)


### PR DESCRIPTION
## ⭐️ Issue Number

- #332 

## 🚩 Summary

- ViewController내에 존재하는 로직을 ViewModel로 이동시켜 MVVM 아키텍쳐를 지키도록 리팩토링한다.
  - 검색 결과가 없는 경우에 대한 분기 처리 로직을 HomeViewController에서 HomeViewModel로 이동한다.
  - FilteredStore가 없는 경우에 대한 분기 처리 로직을 HomeViewController에서 HomeViewModel로 이동한다.
  - 지도가 움직이는 이유에 대한 분기 처리 로직을 HomeViewController에서 HomeViewModel로 이동한다.
  - DetailView에 OpenClosed Type에 따른 분기 처리 로직을 StoreInformationViewController에서 StoreInformationViewController로 이동한다.
