### PR TITLE
Repository API 주입 리팩토링

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		A8AE14D22B87894000A554A8 /* DeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE14D12B87894000A554A8 /* DeleteAllHistoryRepository.swift */; };
 		A8AE14D42B886DE400A554A8 /* ApplyDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE14D32B886DE400A554A8 /* ApplyDiffableDataSource.swift */; };
 		A8AE14D62B886DF700A554A8 /* ReloadDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE14D52B886DF700A554A8 /* ReloadDiffableDataSource.swift */; };
+		A8AE14E42B8A689900A554A8 /* APIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE14E32B8A689900A554A8 /* APIType.swift */; };
 		A8AE4B1B2B62A60B00632355 /* OpeningHoursCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */; };
 		A8AF06702B80B7DC00E73574 /* AutoCompletionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF066F2B80B7DC00E73574 /* AutoCompletionDTO.swift */; };
 		A8AF06722B80BA5E00E73574 /* AutoCompletionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF06712B80BA5E00E73574 /* AutoCompletionResponse.swift */; };
@@ -393,6 +394,7 @@
 		A8AE14D12B87894000A554A8 /* DeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
 		A8AE14D32B886DE400A554A8 /* ApplyDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplyDiffableDataSource.swift; sourceTree = "<group>"; };
 		A8AE14D52B886DF700A554A8 /* ReloadDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReloadDiffableDataSource.swift; sourceTree = "<group>"; };
+		A8AE14E32B8A689900A554A8 /* APIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIType.swift; sourceTree = "<group>"; };
 		A8AE4B1A2B62A60B00632355 /* OpeningHoursCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursCellView.swift; sourceTree = "<group>"; };
 		A8AF066F2B80B7DC00E73574 /* AutoCompletionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompletionDTO.swift; sourceTree = "<group>"; };
 		A8AF06712B80BA5E00E73574 /* AutoCompletionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompletionResponse.swift; sourceTree = "<group>"; };
@@ -893,6 +895,7 @@
 				59C306D42B50629400862625 /* Error */,
 				59C306B72B50033200862625 /* Response */,
 				59C306AB2B4FFABA00862625 /* DTO */,
+				A8AE14E32B8A689900A554A8 /* APIType.swift */,
 				59C306CA2B50357900862625 /* Router.swift */,
 				59C306CC2B5035B100862625 /* StoreAPI.swift */,
 			);
@@ -1472,6 +1475,7 @@
 				594376522B83526D005B97B2 /* UIView+removeFromSuperviewWithAnimation.swift in Sources */,
 				59F478BF2B5BEA08002FEF9E /* RequestLocation.swift in Sources */,
 				5943764A2B8218F2005B97B2 /* FetchStoreIDUseCaseImpl.swift in Sources */,
+				A8AE14E42B8A689900A554A8 /* APIType.swift in Sources */,
 				596DDC4D2B6416AB00A4BBC4 /* SummaryViewContents.swift in Sources */,
 				59C306B22B50001F00862625 /* FetchStoresRepositoryImpl.swift in Sources */,
 				59503A6C2B7980B80006CF35 /* AutoCompletionTableViewCell.swift in Sources */,

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -30,17 +30,29 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let imageCache = ImageCache()
         let userDefaults = UserDefaults()
         
+        // MARK: API
+        let getStoresAPI = StoreAPI<RequestLocationDTO>(type: .getStores)
+        let getImageAPI = StoreAPI<String>(type: .getImage)
+        let getSearchStoresAPI = StoreAPI<SearchDTO>(type: .getSearchStores)
+        let getAutoCompletionAPI = StoreAPI<AutoCompletionDTO>(type: .getAutoCompletion)
+        let postNewStoreRequestAPI = StoreAPI<NewStoreRequestDTO>(type: .postNewStoreRequest)
+        let storeUpdateRequestAPI = StoreAPI<UpdateRequestDTO>(type: .storeUpdateRequest)
+        
         // MARK: Repository
         let fetchStoresRepository = FetchStoresRepositoryImpl(
-            storeStorage: storeStorage
+            storeStorage: storeStorage,
+            storeAPI: getStoresAPI
         )
         let getStoresRepository = GetStoresRepositoryImpl(
             storeStorage: storeStorage
         )
         let fetchSearchStoresRepository = FetchSearchStoresRepositoryImpl(
-            storeStorage: storeStorage
+            storeStorage: storeStorage, 
+            storeAPI: getSearchStoresAPI
         )
-        let storeUpdateRequestRepository = StoreUpdateRequestRepositoryImpl()
+        let storeUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(
+            storeAPI: storeUpdateRequestAPI
+        )
         let fetchStoreIDRepository = FetchStoreIDRepositoryImpl(
             storage: storeIDStorage
         )
@@ -56,9 +68,16 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let deleteAllHistoryRepository = DeleteAllHistoryRepositoryImpl(
             userDefaults: userDefaults
         )
-        let fetchAutoCompletionRepository = FetchAutoCompletionRepositoryImpl()
-        let postNewStoreRepository = PostNewStoreRepositoryImpl()
-        let imageRepository = ImageRepositoryImpl(cache: imageCache)
+        let fetchAutoCompletionRepository = FetchAutoCompletionRepositoryImpl(
+            storeAPI: getAutoCompletionAPI
+        )
+        let postNewStoreRepository = PostNewStoreRepositoryImpl(
+            storeAPI: postNewStoreRequestAPI
+        )
+        let imageRepository = ImageRepositoryImpl(
+            cache: imageCache,
+            storeAPI: getImageAPI
+        )
         let networkRepository = NetworkRepositoryImpl()
         
         // MARK: UseCase

--- a/KCS/KCS/Data/Network/APIType.swift
+++ b/KCS/KCS/Data/Network/APIType.swift
@@ -1,0 +1,19 @@
+//
+//  APIType.swift
+//  KCS
+//
+//  Created by 김영현 on 2/25/24.
+//
+
+import Foundation
+
+enum APIType {
+    
+    case getStores
+    case getImage
+    case getSearchStores
+    case getAutoCompletion
+    case postNewStoreRequest
+    case storeUpdateRequest
+    
+}

--- a/KCS/KCS/Data/Network/Router.swift
+++ b/KCS/KCS/Data/Network/Router.swift
@@ -9,11 +9,16 @@ import Alamofire
 
 protocol Router {
     
-    var baseURL: String? { get }
+    associatedtype RequestValue
+    
+    var type: APIType { get }
+    var baseURL: String? { get set }
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: [String: String] { get }
-    var parameters: [String: Any]? { get }
+    var parameters: [String: Any]? { get set }
     var encoding: ParameterEncoding? { get }
+    
+    func execute(requestValue: RequestValue) -> URLRequest?
     
 }

--- a/KCS/KCS/Data/Network/Router.swift
+++ b/KCS/KCS/Data/Network/Router.swift
@@ -19,6 +19,6 @@ protocol Router {
     var parameters: [String: Any]? { get set }
     var encoding: ParameterEncoding? { get }
     
-    func execute(requestValue: RequestValue) -> URLRequest?
+    func execute(requestValue: RequestValue) throws -> URLRequest
     
 }

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -8,17 +8,6 @@
 import RxSwift
 import Alamofire
 
-enum APIType {
-    
-    case getStores
-    case getImage
-    case getSearchStores
-    case getAutoCompletion
-    case postNewStoreRequest
-    case storeUpdateRequest
-    
-}
-
 final class StoreAPI<T>: Router, URLRequestConvertible {
     
     typealias RequestValue = T

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -8,30 +8,59 @@
 import RxSwift
 import Alamofire
 
-enum StoreAPI {
+enum APIType {
     
-    case getStores(location: RequestLocationDTO)
-    case getImage(url: String)
-    case getSearchStores(searchDTO: SearchDTO)
-    case getAutoCompletion(autoCompletionDTO: AutoCompletionDTO)
-    case postNewStoreRequest(newStoreRequestDTO: NewStoreRequestDTO)
-    case storeUpdateRequest(updateRequestDTO: UpdateRequestDTO)
+    case getStores
+    case getImage
+    case getSearchStores
+    case getAutoCompletion
+    case postNewStoreRequest
+    case storeUpdateRequest
     
 }
 
-extension StoreAPI: Router, URLRequestConvertible {
+final class StoreAPI<T>: Router, URLRequestConvertible {
     
-    var baseURL: String? {
-        switch self {
-        case .getStores, .getSearchStores, .getAutoCompletion, .postNewStoreRequest, .storeUpdateRequest:
-            return getURL(type: .product)
-        case .getImage(let url):
-            return url
+    typealias RequestValue = T
+    
+    let type: APIType
+    
+    init(type: APIType) {
+        self.type = type
+    }
+    
+    func execute(requestValue: T) -> URLRequest? {
+        do {
+            switch type {
+            case .getStores:
+                baseURL = getURL(type: .develop)
+                parameters = try (requestValue as? RequestLocationDTO).asDictionary()
+            case .getImage:
+                baseURL = requestValue as? String
+                parameters = [:]
+            case .getSearchStores:
+                baseURL = getURL(type: .develop)
+                parameters = try (requestValue as? SearchDTO).asDictionary()
+            case .getAutoCompletion:
+                baseURL = getURL(type: .develop)
+                parameters = try (requestValue as? AutoCompletionDTO).asDictionary()
+            case .postNewStoreRequest:
+                baseURL = getURL(type: .develop)
+                parameters = try (requestValue as? NewStoreRequestDTO).asDictionary()
+            case .storeUpdateRequest:
+                baseURL = getURL(type: .develop)
+                parameters = try (requestValue as? UpdateRequestDTO).asDictionary()
+            }
+            return try asURLRequest()
+        } catch {
+            return nil
         }
     }
     
+    var baseURL: String?
+    
     var path: String {
-        switch self {
+        switch type {
         case .getStores:
             return "/storecertification/byLocation/v2"
         case .getImage:
@@ -48,7 +77,7 @@ extension StoreAPI: Router, URLRequestConvertible {
     }
     
     var method: HTTPMethod {
-        switch self {
+        switch type {
         case .getStores, .getImage, .getSearchStores, .getAutoCompletion:
             return .get
         case .postNewStoreRequest, .storeUpdateRequest:
@@ -57,7 +86,7 @@ extension StoreAPI: Router, URLRequestConvertible {
     }
     
     var headers: [String: String] {
-        switch self {
+        switch type {
         case .getStores, .getSearchStores, .getAutoCompletion, .postNewStoreRequest, .storeUpdateRequest:
             return [
                 "Content-Type": "application/json"
@@ -67,31 +96,12 @@ extension StoreAPI: Router, URLRequestConvertible {
         }
     }
     
-    var parameters: [String: Any]? {
-        do {
-            switch self {
-            case let .getStores(location):
-                return try location.asDictionary()
-            case .getImage:
-                return [:]
-            case let .getSearchStores(searchDTO):
-                return try searchDTO.asDictionary()
-            case let .getAutoCompletion(autoCompletionDTO):
-                return try autoCompletionDTO.asDictionary()
-            case let .postNewStoreRequest(newStoreRequestDTO):
-                return try newStoreRequestDTO.asDictionary()
-            case let .storeUpdateRequest(updateRequestDTO):
-                return try updateRequestDTO.asDictionary()
-            }
-        } catch {
-            return nil
-        }
-    }
+    var parameters: [String: Any]?
     
     /// 파라미터로 보내야할 것이 있다면, URLEncoding.default
     /// 바디에 담아서 보내야할 것이 있다면, JSONEncoding.default
     var encoding: ParameterEncoding? {
-        switch self {
+        switch type {
         case .getStores, .getSearchStores, .getAutoCompletion:
             return URLEncoding.default
         case .postNewStoreRequest, .storeUpdateRequest:

--- a/KCS/KCS/Data/Network/StoreAPI.swift
+++ b/KCS/KCS/Data/Network/StoreAPI.swift
@@ -29,7 +29,7 @@ final class StoreAPI<T>: Router, URLRequestConvertible {
         self.type = type
     }
     
-    func execute(requestValue: T) -> URLRequest? {
+    func execute(requestValue: T) throws -> URLRequest {
         do {
             switch type {
             case .getStores:
@@ -52,8 +52,10 @@ final class StoreAPI<T>: Router, URLRequestConvertible {
                 parameters = try (requestValue as? UpdateRequestDTO).asDictionary()
             }
             return try asURLRequest()
+        } catch JSONContentsError.dictionaryConvert {
+            throw NetworkError.wrongParameters
         } catch {
-            return nil
+            throw NetworkError.wrongURL
         }
     }
     

--- a/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
@@ -20,13 +20,13 @@ final class FetchAutoCompletionRepositoryImpl: FetchAutoCompletionRepository {
         searchKeyword: String
     ) -> Observable<[String]> {
         return Observable<[String]>.create { [weak self] observer -> Disposable in
-            guard let self = self,
-                  let urlRequest = storeAPI.execute(
+            do {
+                guard let self = self else { return Disposables.create() }
+                AF.request(try storeAPI.execute(
                     requestValue: AutoCompletionDTO(
                         searchKeyword: searchKeyword
                     )
-                  ) else { return Disposables.create() }
-            AF.request(urlRequest)
+                ))
                 .responseDecodable(of: AutoCompletionResponse.self) { response in
                     switch response.result {
                     case .success(let result):
@@ -45,6 +45,9 @@ final class FetchAutoCompletionRepositoryImpl: FetchAutoCompletionRepository {
                         }
                     }
                 }
+            } catch {
+                observer.onError(error)
+            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchAutoCompletionRepositoryImpl.swift
@@ -10,32 +10,41 @@ import Alamofire
 
 final class FetchAutoCompletionRepositoryImpl: FetchAutoCompletionRepository {
     
+    let storeAPI: StoreAPI<AutoCompletionDTO>
+    
+    init(storeAPI: StoreAPI<AutoCompletionDTO>) {
+        self.storeAPI = storeAPI
+    }
+    
     func fetchAutoCompletion(
         searchKeyword: String
     ) -> Observable<[String]> {
-        return Observable<[String]>.create { observer -> Disposable in
-            AF.request(StoreAPI.getAutoCompletion(
-                autoCompletionDTO: AutoCompletionDTO(
-                    searchKeyword: searchKeyword
-                )))
-            .responseDecodable(of: AutoCompletionResponse.self) { response in
-                switch response.result {
-                case .success(let result):
-                    let autoCompletion = result.data
-                    observer.onNext(autoCompletion)
-                case .failure(let error):
-                    if let underlyingError = error.underlyingError as? NSError {
-                        switch underlyingError.code {
-                        case URLError.notConnectedToInternet.rawValue:
-                            observer.onError(ErrorAlertMessage.internet)
-                        default:
-                            observer.onError(ErrorAlertMessage.server)
+        return Observable<[String]>.create { [weak self] observer -> Disposable in
+            guard let self = self,
+                  let urlRequest = storeAPI.execute(
+                    requestValue: AutoCompletionDTO(
+                        searchKeyword: searchKeyword
+                    )
+                  ) else { return Disposables.create() }
+            AF.request(urlRequest)
+                .responseDecodable(of: AutoCompletionResponse.self) { response in
+                    switch response.result {
+                    case .success(let result):
+                        let autoCompletion = result.data
+                        observer.onNext(autoCompletion)
+                    case .failure(let error):
+                        if let underlyingError = error.underlyingError as? NSError {
+                            switch underlyingError.code {
+                            case URLError.notConnectedToInternet.rawValue:
+                                observer.onError(ErrorAlertMessage.internet)
+                            default:
+                                observer.onError(ErrorAlertMessage.server)
+                            }
+                        } else {
+                            observer.onError(ErrorAlertMessage.client)
                         }
-                    } else {
-                        observer.onError(ErrorAlertMessage.client)
                     }
                 }
-            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/FetchSearchStoresRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchSearchStoresRepositoryImpl.swift
@@ -11,41 +11,47 @@ import Alamofire
 final class FetchSearchStoresRepositoryImpl: FetchSearchStoresRepository {
     
     let storeStorage: StoreStorage
+    let storeAPI: StoreAPI<SearchDTO>
     
-    init(storeStorage: StoreStorage) {
+    init(storeStorage: StoreStorage, storeAPI: StoreAPI<SearchDTO>) {
         self.storeStorage = storeStorage
+        self.storeAPI = storeAPI
     }
     
     func fetchSearchStores(location: Location, keyword: String) -> Observable<[Store]> {
-        return Observable<[Store]>.create { observer -> Disposable in
-            AF.request(StoreAPI.getSearchStores(searchDTO: SearchDTO(
-                currLong: location.longitude,
-                currLat: location.latitude,
-                searchKeyword: keyword
-            )))
-            .responseDecodable(of: SearchStoreResponse.self) { [weak self] response in
-                do {
-                    switch response.result {
-                    case .success(let result):
-                        let resultStores = try result.data.map { try $0.toEntity() }
-                        self?.storeStorage.stores = resultStores
-                        observer.onNext(resultStores)
-                    case .failure(let error):
-                        if let underlyingError = error.underlyingError as? NSError {
-                            switch underlyingError.code {
-                            case URLError.notConnectedToInternet.rawValue:
-                                observer.onError(ErrorAlertMessage.internet)
-                            default:
-                                observer.onError(ErrorAlertMessage.server)
+        return Observable<[Store]>.create { [weak self] observer -> Disposable in
+            guard let self = self,
+                  let urlRequest = storeAPI.execute(
+                    requestValue: SearchDTO(
+                        currLong: location.longitude,
+                        currLat: location.latitude,
+                        searchKeyword: keyword
+                    )
+                  ) else { return Disposables.create() }
+            AF.request(urlRequest)
+                .responseDecodable(of: SearchStoreResponse.self) { [weak self] response in
+                    do {
+                        switch response.result {
+                        case .success(let result):
+                            let resultStores = try result.data.map { try $0.toEntity() }
+                            self?.storeStorage.stores = resultStores
+                            observer.onNext(resultStores)
+                        case .failure(let error):
+                            if let underlyingError = error.underlyingError as? NSError {
+                                switch underlyingError.code {
+                                case URLError.notConnectedToInternet.rawValue:
+                                    observer.onError(ErrorAlertMessage.internet)
+                                default:
+                                    observer.onError(ErrorAlertMessage.server)
+                                }
+                            } else {
+                                observer.onError(ErrorAlertMessage.client)
                             }
-                        } else {
-                            observer.onError(ErrorAlertMessage.client)
                         }
+                    } catch {
+                        observer.onError(error)
                     }
-                } catch {
-                    observer.onError(error)
                 }
-            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/FetchSearchStoresRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchSearchStoresRepositoryImpl.swift
@@ -20,15 +20,15 @@ final class FetchSearchStoresRepositoryImpl: FetchSearchStoresRepository {
     
     func fetchSearchStores(location: Location, keyword: String) -> Observable<[Store]> {
         return Observable<[Store]>.create { [weak self] observer -> Disposable in
-            guard let self = self,
-                  let urlRequest = storeAPI.execute(
+            do {
+                guard let self = self else { return Disposables.create() }
+                AF.request(try storeAPI.execute(
                     requestValue: SearchDTO(
                         currLong: location.longitude,
                         currLat: location.latitude,
                         searchKeyword: keyword
                     )
-                  ) else { return Disposables.create() }
-            AF.request(urlRequest)
+                ))
                 .responseDecodable(of: SearchStoreResponse.self) { [weak self] response in
                     do {
                         switch response.result {
@@ -52,6 +52,9 @@ final class FetchSearchStoresRepositoryImpl: FetchSearchStoresRepository {
                         observer.onError(error)
                     }
                 }
+            } catch {
+                observer.onError(error)
+            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
@@ -11,64 +11,70 @@ import Alamofire
 final class FetchStoresRepositoryImpl: FetchStoresRepository {
     
     let storeStorage: StoreStorage
+    let storeAPI: StoreAPI<RequestLocationDTO>
     
-    init(storeStorage: StoreStorage) {
+    init(storeStorage: StoreStorage, storeAPI: StoreAPI<RequestLocationDTO>) {
         self.storeStorage = storeStorage
+        self.storeAPI = storeAPI
     }
     
     func fetchStores(
         requestLocation: RequestLocation,
         isEntire: Bool
     ) -> Observable<FetchStores> {
-        return Observable<FetchStores>.create { observer -> Disposable in
-            AF.request(StoreAPI.getStores(location: RequestLocationDTO(
-                nwLong: requestLocation.northWest.longitude,
-                nwLat: requestLocation.northWest.latitude,
-                swLong: requestLocation.southWest.longitude,
-                swLat: requestLocation.southWest.latitude,
-                seLong: requestLocation.southEast.longitude,
-                seLat: requestLocation.southEast.latitude,
-                neLong: requestLocation.northEast.longitude,
-                neLat: requestLocation.northEast.latitude
-            )))
-            .responseDecodable(of: RefreshStoreResponse.self) { [weak self] response in
-                do {
-                    switch response.result {
-                    case .success(let result):
-                        let resultStores = try result.data.map { try $0.map { try $0.toEntity() } }
-                        self?.storeStorage.stores = resultStores.flatMap({ $0 })
-                        if isEntire {
-                            observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
-                                stores: resultStores.flatMap { $0 }
-                            ))
-                        } else if let firstIndexStore = resultStores.first {
-                            observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count, fetchCount: 1),
-                                stores: firstIndexStore
-                            ))
-                        } else {
-                            observer.onNext(FetchStores(
-                                fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
-                                stores: []
-                            ))
-                        }
-                    case .failure(let error):
-                        if let underlyingError = error.underlyingError as? NSError {
-                            switch underlyingError.code {
-                            case URLError.notConnectedToInternet.rawValue:
-                                observer.onError(ErrorAlertMessage.internet)
-                            default:
-                                observer.onError(ErrorAlertMessage.server)
+        return Observable<FetchStores>.create { [weak self] observer -> Disposable in
+            guard let self = self,
+                  let urlRequest = storeAPI.execute(
+                    requestValue: RequestLocationDTO(
+                        nwLong: requestLocation.northWest.longitude,
+                        nwLat: requestLocation.northWest.latitude,
+                        swLong: requestLocation.southWest.longitude,
+                        swLat: requestLocation.southWest.latitude,
+                        seLong: requestLocation.southEast.longitude,
+                        seLat: requestLocation.southEast.latitude,
+                        neLong: requestLocation.northEast.longitude,
+                        neLat: requestLocation.northEast.latitude
+                    )
+                  ) else { return Disposables.create() }
+            AF.request(urlRequest)
+                .responseDecodable(of: RefreshStoreResponse.self) { [weak self] response in
+                    do {
+                        switch response.result {
+                        case .success(let result):
+                            let resultStores = try result.data.map { try $0.map { try $0.toEntity() } }
+                            self?.storeStorage.stores = resultStores.flatMap({ $0 })
+                            if isEntire {
+                                observer.onNext(FetchStores(
+                                    fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
+                                    stores: resultStores.flatMap { $0 }
+                                ))
+                            } else if let firstIndexStore = resultStores.first {
+                                observer.onNext(FetchStores(
+                                    fetchCountContent: FetchCountContent(maxFetchCount: resultStores.count, fetchCount: 1),
+                                    stores: firstIndexStore
+                                ))
+                            } else {
+                                observer.onNext(FetchStores(
+                                    fetchCountContent: FetchCountContent(maxFetchCount: 1, fetchCount: 1),
+                                    stores: []
+                                ))
                             }
-                        } else {
-                            observer.onError(ErrorAlertMessage.client)
+                        case .failure(let error):
+                            if let underlyingError = error.underlyingError as? NSError {
+                                switch underlyingError.code {
+                                case URLError.notConnectedToInternet.rawValue:
+                                    observer.onError(ErrorAlertMessage.internet)
+                                default:
+                                    observer.onError(ErrorAlertMessage.server)
+                                }
+                            } else {
+                                observer.onError(ErrorAlertMessage.client)
+                            }
                         }
+                    } catch {
+                        observer.onError(error)
                     }
-                } catch {
-                    observer.onError(error)
                 }
-            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/FetchStoresRepositoryImpl.swift
@@ -23,8 +23,9 @@ final class FetchStoresRepositoryImpl: FetchStoresRepository {
         isEntire: Bool
     ) -> Observable<FetchStores> {
         return Observable<FetchStores>.create { [weak self] observer -> Disposable in
-            guard let self = self,
-                  let urlRequest = storeAPI.execute(
+            do {
+                guard let self = self else { return Disposables.create() }
+                AF.request(try storeAPI.execute(
                     requestValue: RequestLocationDTO(
                         nwLong: requestLocation.northWest.longitude,
                         nwLat: requestLocation.northWest.latitude,
@@ -35,8 +36,7 @@ final class FetchStoresRepositoryImpl: FetchStoresRepository {
                         neLong: requestLocation.northEast.longitude,
                         neLat: requestLocation.northEast.latitude
                     )
-                  ) else { return Disposables.create() }
-            AF.request(urlRequest)
+                ))
                 .responseDecodable(of: RefreshStoreResponse.self) { [weak self] response in
                     do {
                         switch response.result {
@@ -75,6 +75,9 @@ final class FetchStoresRepositoryImpl: FetchStoresRepository {
                         observer.onError(error)
                     }
                 }
+            } catch {
+                observer.onError(error)
+            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/ImageRepositoryImpl.swift
@@ -11,6 +11,7 @@ import Alamofire
 struct ImageRepositoryImpl: ImageRepository {
     
     let cache: ImageCache
+    let storeAPI: StoreAPI<String>
     
     func fetchImage(
         url: String
@@ -20,7 +21,8 @@ struct ImageRepositoryImpl: ImageRepository {
                 if let imageData = cache.getImageData(for: imageURL as NSURL) {
                     observer.onNext(Data(imageData))
                 } else {
-                    AF.request(StoreAPI.getImage(url: url))
+                    guard let urlRequest = storeAPI.execute(requestValue: url) else { return Disposables.create() }
+                    AF.request(urlRequest)
                         .response(completionHandler: { response in
                             switch response.result {
                             case .success(let result):

--- a/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
@@ -10,32 +10,40 @@ import Alamofire
 
 final class PostNewStoreRepositoryImpl: PostNewStoreRepository {
     
+    let storeAPI: StoreAPI<NewStoreRequestDTO>
+    
+    init(storeAPI: StoreAPI<NewStoreRequestDTO>) {
+        self.storeAPI = storeAPI
+    }
+    
     func postNewStore(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
-        return Observable<Void>.create { observer -> Disposable in
-            AF.request(StoreAPI.postNewStoreRequest(
-                newStoreRequestDTO: NewStoreRequestDTO(
-                    storeName: storeName,
-                    formattedAddress: formattedAddress,
-                    certifications: certifications.map { $0.rawValue }
-                )
-            ))
-            .response { response in
-                switch response.result {
-                case .success:
-                    observer.onNext(())
-                case .failure(let error):
-                    if let underlyingError = error.underlyingError as? NSError {
-                        switch underlyingError.code {
-                        case URLError.notConnectedToInternet.rawValue:
-                            observer.onError(ErrorAlertMessage.internet)
-                        default:
-                            observer.onError(ErrorAlertMessage.server)
+        return Observable<Void>.create { [weak self] observer -> Disposable in
+            guard let self = self,
+                  let urlRequest = storeAPI.execute(
+                    requestValue: NewStoreRequestDTO(
+                        storeName: storeName,
+                        formattedAddress: formattedAddress,
+                        certifications: certifications.map { $0.rawValue }
+                    )
+                  ) else { return Disposables.create() }
+            AF.request(urlRequest)
+                .response { response in
+                    switch response.result {
+                    case .success:
+                        observer.onNext(())
+                    case .failure(let error):
+                        if let underlyingError = error.underlyingError as? NSError {
+                            switch underlyingError.code {
+                            case URLError.notConnectedToInternet.rawValue:
+                                observer.onError(ErrorAlertMessage.internet)
+                            default:
+                                observer.onError(ErrorAlertMessage.server)
+                            }
+                        } else {
+                            observer.onError(ErrorAlertMessage.client)
                         }
-                    } else {
-                        observer.onError(ErrorAlertMessage.client)
                     }
                 }
-            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/PostNewStoreRepositoryImpl.swift
@@ -18,15 +18,15 @@ final class PostNewStoreRepositoryImpl: PostNewStoreRepository {
     
     func postNewStore(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
         return Observable<Void>.create { [weak self] observer -> Disposable in
-            guard let self = self,
-                  let urlRequest = storeAPI.execute(
+            do {
+                guard let self = self else { return Disposables.create() }
+                AF.request(try storeAPI.execute(
                     requestValue: NewStoreRequestDTO(
                         storeName: storeName,
                         formattedAddress: formattedAddress,
                         certifications: certifications.map { $0.rawValue }
                     )
-                  ) else { return Disposables.create() }
-            AF.request(urlRequest)
+                ))
                 .response { response in
                     switch response.result {
                     case .success:
@@ -44,6 +44,9 @@ final class PostNewStoreRepositoryImpl: PostNewStoreRepository {
                         }
                     }
                 }
+            } catch {
+                observer.onError(error)
+            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/StoreUpdateRequestRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreUpdateRequestRepositoryImpl.swift
@@ -18,15 +18,15 @@ final class StoreUpdateRequestRepositoryImpl: StoreUpdateRequestRepository {
     
     func storeUpdateReqeust(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
         return Observable<Void>.create { [weak self] observer -> Disposable in
-            guard let self = self,
-                  let urlRequest = storeAPI.execute(
+            do {
+                guard let self = self else { return Disposables.create() }
+                AF.request(try storeAPI.execute(
                     requestValue: UpdateRequestDTO(
                         dtype: type.rawValue,
                         storeId: storeID,
                         contents: content
                     )
-                  ) else { return Disposables.create() }
-            AF.request(urlRequest)
+                ))
                 .response { response in
                     switch response.result {
                     case .success:
@@ -44,6 +44,9 @@ final class StoreUpdateRequestRepositoryImpl: StoreUpdateRequestRepository {
                         }
                     }
                 }
+            } catch {
+                observer.onError(error)
+            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Data/Repository/StoreUpdateRequestRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/StoreUpdateRequestRepositoryImpl.swift
@@ -10,33 +10,40 @@ import Alamofire
 
 final class StoreUpdateRequestRepositoryImpl: StoreUpdateRequestRepository {
     
+    let storeAPI: StoreAPI<UpdateRequestDTO>
+    
+    init(storeAPI: StoreAPI<UpdateRequestDTO>) {
+        self.storeAPI = storeAPI
+    }
+    
     func storeUpdateReqeust(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
-        return Observable<Void>.create { observer -> Disposable in
-            AF.request(StoreAPI.storeUpdateRequest(
-                updateRequestDTO:
-                    UpdateRequestDTO(
+        return Observable<Void>.create { [weak self] observer -> Disposable in
+            guard let self = self,
+                  let urlRequest = storeAPI.execute(
+                    requestValue: UpdateRequestDTO(
                         dtype: type.rawValue,
                         storeId: storeID,
                         contents: content
                     )
-            ))
-            .response { response in
-                switch response.result {
-                case .success:
-                    observer.onNext(())
-                case .failure(let error):
-                    if let underlyingError = error.underlyingError as? NSError {
-                        switch underlyingError.code {
-                        case URLError.notConnectedToInternet.rawValue:
-                            observer.onError(ErrorAlertMessage.internet)
-                        default:
-                            observer.onError(ErrorAlertMessage.server)
+                  ) else { return Disposables.create() }
+            AF.request(urlRequest)
+                .response { response in
+                    switch response.result {
+                    case .success:
+                        observer.onNext(())
+                    case .failure(let error):
+                        if let underlyingError = error.underlyingError as? NSError {
+                            switch underlyingError.code {
+                            case URLError.notConnectedToInternet.rawValue:
+                                observer.onError(ErrorAlertMessage.internet)
+                            default:
+                                observer.onError(ErrorAlertMessage.server)
+                            }
+                        } else {
+                            observer.onError(ErrorAlertMessage.client)
                         }
-                    } else {
-                        observer.onError(ErrorAlertMessage.client)
                     }
                 }
-            }
             return Disposables.create()
         }
     }

--- a/KCS/KCS/Domain/Interface/Repository/FetchAutoCompletionRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/FetchAutoCompletionRepository.swift
@@ -9,6 +9,8 @@ import RxSwift
 
 protocol FetchAutoCompletionRepository {
     
+    var storeAPI: StoreAPI<AutoCompletionDTO> { get }
+    
     func fetchAutoCompletion(
         searchKeyword: String
     ) -> Observable<[String]>

--- a/KCS/KCS/Domain/Interface/Repository/FetchSearchStoresRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/FetchSearchStoresRepository.swift
@@ -10,6 +10,7 @@ import RxSwift
 protocol FetchSearchStoresRepository {
     
     var storeStorage: StoreStorage { get }
+    var storeAPI: StoreAPI<SearchDTO> { get }
     
     func fetchSearchStores(
         location: Location,

--- a/KCS/KCS/Domain/Interface/Repository/FetchStoresRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/FetchStoresRepository.swift
@@ -10,6 +10,7 @@ import RxSwift
 protocol FetchStoresRepository {
     
     var storeStorage: StoreStorage { get }
+    var storeAPI: StoreAPI<RequestLocationDTO> { get }
     
     func fetchStores(
         requestLocation: RequestLocation,

--- a/KCS/KCS/Domain/Interface/Repository/ImageRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/ImageRepository.swift
@@ -10,6 +10,7 @@ import RxSwift
 protocol ImageRepository {
     
     var cache: ImageCache { get }
+    var storeAPI: StoreAPI<String> { get }
     
     func fetchImage(
         url: String

--- a/KCS/KCS/Domain/Interface/Repository/PostNewStoreRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/PostNewStoreRepository.swift
@@ -9,6 +9,8 @@ import RxSwift
 
 protocol PostNewStoreRepository {
     
+    var storeAPI: StoreAPI<NewStoreRequestDTO> { get }
+    
     func postNewStore(
         storeName: String,
         formattedAddress: String,

--- a/KCS/KCS/Domain/Interface/Repository/StoreUpdateRequestRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/StoreUpdateRequestRepository.swift
@@ -9,6 +9,8 @@ import RxSwift
 
 protocol StoreUpdateRequestRepository {
     
+    var storeAPI: StoreAPI<UpdateRequestDTO> { get }
+    
     func storeUpdateReqeust(
         type: StoreUpdateRequestType,
         storeID: Int,


### PR DESCRIPTION
## ⭐️ Issue Number

- #336 

## 🚩 Summary

- Repository들이 API 연동 함수를 외부로부터 주입 받을 수 있는 형태로 리팩토링한다.

## 🛠️ Technical Concerns

### API의 주입

추후 Repository의 테스트코드를 작성하기 위해서 MockSever를 만들어야 하고, MockServer를 사용하여 Repository를 테스트하기 위해서는 URLRequest를 외부에서 주입받아야했다.
수정 전 코드는 enum으로 분리하여 모든 API콜을 위한 URLRequest를 하나의 열거형으로 처리해 주었다. 
enum으로 만든 API URLRequest는 외부에서 주입받을 수 없는 형태이기 때문에, 형태를 변환시킬 필요가 있었다.
StoreAPI를 외부에서 주입 가능한 클래스 구조로 바꾸는 과정에서 다음 두 가지 사항을 지키며 구현하고 싶었다.

- URLRequest를 생성하는 코드는 중복되므로, 재활용 가능하게 만든다.
- API별로 필요한 값들의 타입은 주입받는 곳에서 결정해주되, 실제 parameter나 url에 들어가야하는 값은 repository에서 설정할 수 있게 한다.

위 두 가지 사항을 만족시키는 코드를 작성하기 위해, Generic을 사용했으며, 이니셜라이져에 어떤 API인지 타입을 정할 수 있도록 해주었다.

```swift
final class StoreAPI<T>: Router, URLRequestConvertible {
    
    typealias RequestValue = T
    
    let type: APIType
    
    init(type: APIType) {
        self.type = type
    }
    
    func execute(requestValue: T) throws -> URLRequest {
        do {
            switch type {
            case .getStores:
                baseURL = getURL(type: .develop)
                parameters = try (requestValue as? RequestLocationDTO).asDictionary()
            case .getImage:
                baseURL = requestValue as? String
                parameters = [:]
            ...
            }
            return try asURLRequest()
        }
    }
    ...
}
```

또한 type에 따라 바뀔 수 있는 parameter와 baseURL의 경우 Router 프로토콜에서 set도 가능하도록 수정해 주었다.
```swift
protocol Router {
    
    associatedtype RequestValue
    
    var type: APIType { get }
    var baseURL: String? { get set }
    var path: String { get }
    var method: HTTPMethod { get }
    var headers: [String: String] { get }
    var parameters: [String: Any]? { get set }
    var encoding: ParameterEncoding? { get }
    
    func execute(requestValue: RequestValue) throws -> URLRequest
    
}
```