### PR TITLE
FetchRecentSearchHistoryRepositoryImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		A8E53C2B2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C2A2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift */; };
 		A8EC5B002B8F9B1D00D9182F /* MockFailureNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C0308E2B8E4DC800A1A6FB /* MockFailureNetworkRepository.swift */; };
 		A8EC5B012B8F9B1F00D9182F /* MockSuccessNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C030902B8E4E0A00A1A6FB /* MockSuccessNetworkRepository.swift */; };
+		A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B052B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift */; };
+		A8EC5B082B9055E300D9182F /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B072B9055E300D9182F /* MockUserDefaults.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
@@ -421,6 +423,8 @@
 		A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStorage.swift; sourceTree = "<group>"; };
 		A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoresRepositoryImpl.swift; sourceTree = "<group>"; };
 		A8E53C2A2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSearchStoresRepositoryImpl.swift; sourceTree = "<group>"; };
+		A8EC5B052B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRecentSearchHistoryRepositoryImplTests.swift; sourceTree = "<group>"; };
+		A8EC5B072B9055E300D9182F /* MockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -493,6 +497,7 @@
 			children = (
 				594376942B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift */,
 				A82674982B8D059C004710CB /* FetchImageRepositoryImplTests.swift */,
+				A8EC5B052B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift */,
 			);
 			path = RepositoryTest;
 			sourceTree = "<group>";
@@ -1032,6 +1037,7 @@
 			children = (
 				A82674872B8CF623004710CB /* MockImage.jpeg */,
 				A826749A2B8D0BB0004710CB /* MockImage.swift */,
+				A8EC5B072B9055E300D9182F /* MockUserDefaults.swift */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -1597,6 +1603,7 @@
 			files = (
 				A826749B2B8D0BB1004710CB /* MockImage.swift in Sources */,
 				A82674662B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift in Sources */,
+				A8EC5B082B9055E300D9182F /* MockUserDefaults.swift in Sources */,
 				A8EC5B012B8F9B1F00D9182F /* MockSuccessNetworkRepository.swift in Sources */,
 				A82674992B8D059D004710CB /* FetchImageRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
@@ -1604,6 +1611,7 @@
 				A8EC5B002B8F9B1D00D9182F /* MockFailureNetworkRepository.swift in Sources */,
 				A82674692B8C7AD7004710CB /* MockSuccessImageRepository.swift in Sources */,
 				A826746A2B8C7AD7004710CB /* MockFailureImageRepository.swift in Sources */,
+				A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A82674652B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KCS/KCS/Application/SceneDelegate.swift
+++ b/KCS/KCS/Application/SceneDelegate.swift
@@ -29,7 +29,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let storeStorage = StoreStorage()
         let storeIDStorage = StoreIDStorage()
         let imageCache = ImageCache(cache: NSCache<NSURL, NSData>())
-        let userDefaults = UserDefaults()
+        let userDefaults = UserDefaults.standard
         
         // MARK: Network Session
         let session = Session.default

--- a/KCS/KCSUnitTest/Mock/Resource/MockUserDefaults.swift
+++ b/KCS/KCSUnitTest/Mock/Resource/MockUserDefaults.swift
@@ -1,0 +1,21 @@
+//
+//  MockUserDefaults.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 2/29/24.
+//
+
+import Foundation
+
+final class MockUserDefaults: UserDefaults {
+    
+    convenience init() {
+        self.init(suiteName: "MockUserDefaults")!
+    }
+    
+    override init?(suiteName suitename: String?) {
+        UserDefaults().removePersistentDomain(forName: suitename!)
+        super.init(suiteName: suitename)
+    }
+    
+}

--- a/KCS/KCSUnitTest/RepositoryTest/FetchImageRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchImageRepositoryImplTests.swift
@@ -11,7 +11,7 @@ import Alamofire
 import RxSwift
 import RxBlocking
 
-struct FetchImageRepositoryImplTestsEntity {
+struct FetchImageRepositoryImplTestsConstant {
     
     enum MockURLString: String {
         
@@ -53,7 +53,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
         // Given
         MockURLProtocol.responseWithStatusCode(code: 200)
         MockURLProtocol.setResponseFile(type: .fetchImageFile)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.cache.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.cache.rawValue
         let imageData = mockImage.getImageURL(imageString: imageString)
         guard let url = NSURL(string: urlString) else {
             XCTFail("데이터 변환 실패")
@@ -84,7 +84,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
         // Given
         MockURLProtocol.responseWithStatusCode(code: 200)
         MockURLProtocol.setResponseFile(type: .fetchImageFile)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.noCache.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.noCache.rawValue
         let imageData = mockImage.getImageURL(imageString: imageString)
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
@@ -110,7 +110,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
         // Given
         MockURLProtocol.responseWithStatusCode(code: 200)
         MockURLProtocol.setResponseFile(type: .fetchImageFileFail)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.fail.rawValue
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
             session: session
@@ -132,7 +132,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
         // Given
         MockURLProtocol.responseWithStatusCode(code: 200)
         MockURLProtocol.setResponseFile(type: .fetchImageFileFail)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.wrongURL.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.wrongURL.rawValue
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
             session: session
@@ -153,7 +153,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
     func test_인터넷_연결에_실패한_경우() {
         // Given
         MockURLProtocol.responseWithFailure(error: .noInternetConnection)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.fail.rawValue
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
             session: session
@@ -174,7 +174,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
     func test_서버_연결에_실패한_경우() {
         // Given
         MockURLProtocol.responseWithFailure(error: .noServerConnection)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.fail.rawValue
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
             session: session
@@ -195,7 +195,7 @@ final class FetchImageRepositoryImplTests: XCTestCase {
     func test_Alamofire_통신에_실패한_경우() {
         // Given
         MockURLProtocol.responseWithFailure(error: .alamofireError)
-        let urlString = FetchImageRepositoryImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageRepositoryImplTestsConstant.MockURLString.fail.rawValue
         fetchImageRepository = FetchImageRepositoryImpl(
             cache: imageCache,
             session: session

--- a/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
@@ -1,0 +1,67 @@
+//
+//  FetchRecentSearchHistoryRepositoryImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 2/29/24.
+//
+
+import XCTest
+@testable import KCS
+import RxSwift
+import RxBlocking
+
+final class FetchRecentSearchHistoryRepositoryImplTestsEntity {
+    
+    let emptyRecentHistory: [String] = []
+    let RecentHistory: [String] = ["검색어1", "검색어2", "검색어3"]
+    
+}
+
+final class FetchRecentSearchHistoryRepositoryImplTests: XCTestCase {
+    
+    private var fetchRecentSearchHistoryRepository: FetchRecentSearchHistoryRepository!
+    private var userDefaults: MockUserDefaults!
+    private var fetchRecentSearchHistoryRepositoryImplTestsEntity: FetchRecentSearchHistoryRepositoryImplTestsEntity!
+
+    override func setUp() {
+        userDefaults = MockUserDefaults()
+        fetchRecentSearchHistoryRepositoryImplTestsEntity = FetchRecentSearchHistoryRepositoryImplTestsEntity()
+        fetchRecentSearchHistoryRepository = FetchRecentSearchHistoryRepositoryImpl(
+            userDefaults: userDefaults
+        )
+    }
+    
+    func test_userDefaults에서_빈_배열값을_가져오는_경우() {
+        // Given
+        let key = "recentSearchKeywords"
+        
+        // When
+        let result = fetchRecentSearchHistoryRepository.fetchRecentSearchHistory().toBlocking()
+        
+        // Then
+        do {
+            let resultArray = try result.first()
+            XCTAssertEqual(resultArray, fetchRecentSearchHistoryRepositoryImplTestsEntity.emptyRecentHistory)
+        } catch {
+            XCTFail("빈 배열 불러오기 실패")
+        }
+    }
+    
+    func test_userDefaults에서_문자열_배열값을_가져오는_경우() {
+        // Given
+        let key = "recentSearchKeywords"
+        userDefaults.set(fetchRecentSearchHistoryRepositoryImplTestsEntity.RecentHistory, forKey: key)
+        
+        // When
+        let result = fetchRecentSearchHistoryRepository.fetchRecentSearchHistory().toBlocking()
+        
+        // Then
+        do {
+            let resultArray = try result.first()
+            XCTAssertEqual(resultArray, userDefaults.array(forKey: key) as? [String])
+        } catch {
+            XCTFail("문자열 배열 불러오기 실패")
+        }
+    }
+
+}

--- a/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxBlocking
 
-final class FetchRecentSearchHistoryRepositoryImplTestsEntity {
+struct FetchRecentSearchHistoryRepositoryImplTestsEntity {
     
     let emptyRecentHistory: [String] = []
     let RecentHistory: [String] = ["검색어1", "검색어2", "검색어3"]
@@ -32,15 +32,14 @@ final class FetchRecentSearchHistoryRepositoryImplTests: XCTestCase {
     }
     
     func test_userDefaults에서_빈_배열값을_가져오는_경우() {
-        // Given
-        let key = "recentSearchKeywords"
-        
+        // Given initial state
         // When
         let result = fetchRecentSearchHistoryRepository.fetchRecentSearchHistory().toBlocking()
         
-        // Then
         do {
             let resultArray = try result.first()
+            
+            // Then
             XCTAssertEqual(resultArray, fetchRecentSearchHistoryRepositoryImplTestsEntity.emptyRecentHistory)
         } catch {
             XCTFail("빈 배열 불러오기 실패")
@@ -55,9 +54,10 @@ final class FetchRecentSearchHistoryRepositoryImplTests: XCTestCase {
         // When
         let result = fetchRecentSearchHistoryRepository.fetchRecentSearchHistory().toBlocking()
         
-        // Then
         do {
             let resultArray = try result.first()
+            
+            // Then
             XCTAssertEqual(resultArray, userDefaults.array(forKey: key) as? [String])
         } catch {
             XCTFail("문자열 배열 불러오기 실패")

--- a/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchRecentSearchHistoryRepositoryImplTests.swift
@@ -10,8 +10,9 @@ import XCTest
 import RxSwift
 import RxBlocking
 
-struct FetchRecentSearchHistoryRepositoryImplTestsEntity {
+struct FetchRecentSearchHistoryRepositoryImplTestsConstant {
     
+    let key = "recentSearchKeywords"
     let emptyRecentHistory: [String] = []
     let RecentHistory: [String] = ["검색어1", "검색어2", "검색어3"]
     
@@ -21,11 +22,11 @@ final class FetchRecentSearchHistoryRepositoryImplTests: XCTestCase {
     
     private var fetchRecentSearchHistoryRepository: FetchRecentSearchHistoryRepository!
     private var userDefaults: MockUserDefaults!
-    private var fetchRecentSearchHistoryRepositoryImplTestsEntity: FetchRecentSearchHistoryRepositoryImplTestsEntity!
+    private var fetchRecentSearchHistoryRepositoryImplTestsEntity: FetchRecentSearchHistoryRepositoryImplTestsConstant!
 
     override func setUp() {
         userDefaults = MockUserDefaults()
-        fetchRecentSearchHistoryRepositoryImplTestsEntity = FetchRecentSearchHistoryRepositoryImplTestsEntity()
+        fetchRecentSearchHistoryRepositoryImplTestsEntity = FetchRecentSearchHistoryRepositoryImplTestsConstant()
         fetchRecentSearchHistoryRepository = FetchRecentSearchHistoryRepositoryImpl(
             userDefaults: userDefaults
         )
@@ -48,7 +49,7 @@ final class FetchRecentSearchHistoryRepositoryImplTests: XCTestCase {
     
     func test_userDefaults에서_문자열_배열값을_가져오는_경우() {
         // Given
-        let key = "recentSearchKeywords"
+        let key = fetchRecentSearchHistoryRepositoryImplTestsEntity.key
         userDefaults.set(fetchRecentSearchHistoryRepositoryImplTestsEntity.RecentHistory, forKey: key)
         
         // When

--- a/KCS/KCSUnitTest/RepositoryTest/FetchSearchStoresRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchSearchStoresRepositoryImplTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import Alamofire
 import RxBlocking
 
-final class FetchSearchStoresRepositoryImplTestsEntity {
+final class FetchSearchStoresRepositoryImplTestsConstant {
     
     var emptyStoreArray: [Store] = []
     var oneStore: [Store] = []
@@ -74,7 +74,7 @@ final class FetchSearchStoresRepositoryImplTests: XCTestCase {
     private var fetchSearchStoresRepository: FetchSearchStoresRepository!
     private var storeStorage: StoreStorage!
     private var disposeBag: DisposeBag!
-    private var testEntity: FetchSearchStoresRepositoryImplTestsEntity!
+    private var testEntity: FetchSearchStoresRepositoryImplTestsConstant!
     
     override func setUp() {
         let session: Session = {
@@ -92,7 +92,7 @@ final class FetchSearchStoresRepositoryImplTests: XCTestCase {
             session: session
         )
         disposeBag = DisposeBag()
-        testEntity = FetchSearchStoresRepositoryImplTestsEntity()
+        testEntity = FetchSearchStoresRepositoryImplTestsConstant()
     }
 
     func test_Store_0개를_받아_성공한_경우() {

--- a/KCS/KCSUnitTest/RepositoryTest/FetchStoresRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/FetchStoresRepositoryImplTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import Alamofire
 import RxBlocking
 
-final class FetchStoresRepositoryImplTestsEntity {
+final class FetchStoresRepositoryImplTestsConstant {
     
     let emptyStoreArray: [Store] = []
     var stores: [[Store]] = []
@@ -53,7 +53,7 @@ final class FetchStoresRepositoryImplTests: XCTestCase {
     private var fetchStoresRepository: FetchStoresRepositoryImpl!
     private var storeStorage: StoreStorage!
     private var disposeBag: DisposeBag!
-    private var testEntity: FetchStoresRepositoryImplTestsEntity!
+    private var testEntity: FetchStoresRepositoryImplTestsConstant!
     
     override func setUp() {
         let session: Session = {
@@ -70,7 +70,7 @@ final class FetchStoresRepositoryImplTests: XCTestCase {
             session: session
         )
         disposeBag = DisposeBag()
-        testEntity = FetchStoresRepositoryImplTestsEntity()
+        testEntity = FetchStoresRepositoryImplTestsConstant()
     }
     
     func test_Store_0개를_받아_성공한_경우() {

--- a/KCS/KCSUnitTest/RepositoryTest/GetStoresRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/GetStoresRepositoryImplTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import KCS
 import RxSwift
 
-final class GetStoresRepositoryImplTestsEntity {
+final class GetStoresRepositoryImplTestsConstant {
     
     let emptyStoreArray: [Store] = []
     var stores: [Store] = []
@@ -43,13 +43,13 @@ final class GetStoresRepositoryImplTests: XCTestCase {
     private var getStoresRepository: GetStoresRepository!
     private var storeStorage: StoreStorage!
     private var disposeBag: DisposeBag!
-    private var testEntity: GetStoresRepositoryImplTestsEntity!
+    private var testEntity: GetStoresRepositoryImplTestsConstant!
     
     override func setUp() {
         storeStorage = StoreStorage()
         getStoresRepository = GetStoresRepositoryImpl(storeStorage: storeStorage)
         disposeBag = DisposeBag()
-        testEntity = GetStoresRepositoryImplTestsEntity()
+        testEntity = GetStoresRepositoryImplTestsConstant()
     }
 
     func test_Store가_0개인_경우() {

--- a/KCS/KCSUnitTest/UseCaseTest/FetchImageUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/FetchImageUseCaseImplTests.swift
@@ -10,14 +10,13 @@ import XCTest
 import RxSwift
 import RxBlocking
 
-struct FetchImageUseCaseImplTestsEntity {
+struct FetchImageUseCaseImplTestsConstant {
     
     enum MockURLString: String {
         
         case cache = "test_cache_image_URL"
         case noCache = "test_no_cache_image_URL"
         case fail = "url"
-        case wrongURL = ""
         
     }
     
@@ -39,7 +38,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
     
     func test_캐시데이터에_이미지가_존재하는_경우() {
         // Given
-        let urlString = FetchImageUseCaseImplTestsEntity.MockURLString.cache.rawValue
+        let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.cache.rawValue
         guard let url = NSURL(string: urlString) else {
             XCTFail("데이터 변환 실패")
             return
@@ -70,7 +69,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
 
     func test_캐시데이터에_이미지가_존재하지_않는_경우() {
         // Given
-        let urlString = FetchImageUseCaseImplTestsEntity.MockURLString.noCache.rawValue
+        let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.noCache.rawValue
         let imageData = mockImage.getImageURL(imageString: imageString)
         fetchImageUseCase = FetchImageUseCaseImpl(
             repository: MockSuccessImageRepository(
@@ -95,7 +94,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
     
     func test_URL에_맞는_이미지_데이터가_없는_경우() {
         // Given
-        let urlString = FetchImageUseCaseImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.fail.rawValue
         fetchImageUseCase = FetchImageUseCaseImpl(
             repository: MockNoImageFailureImageRepository(
                 cache: imageCache
@@ -116,7 +115,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
     
     func test_API_호출이_실패한_경우() {
         // Given
-        let urlString = FetchImageUseCaseImplTestsEntity.MockURLString.fail.rawValue
+        let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.fail.rawValue
         fetchImageUseCase = FetchImageUseCaseImpl(
             repository: MockAPIFailureImageRepository(
                 cache: imageCache


### PR DESCRIPTION
## ⭐️ Issue Number

- #352 

## 🚩 Summary

- FetchRecentSearchHistoryRepositoryImpl의 테스트 코드를 작성한다.

<img width="1039" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/62226667/5968cccc-d44c-410c-b1c8-a4592882138d">


## 🛠️ Technical Concerns

### MockUserDefaults

최근 검색어는 우리 프로젝트에서 UserDefaults를 사용하여 관리하고 있다. 
실제 앱에서 사용되는 UserDefaults값에 영향이 가지 않게 하면서 UserDefaults에서 값을 잘 받아오는지 확인하기 위하여 다음과 같이 MockUserDefaults를 생성하고 이를 사용하여 테스트를 진행하였다.
```swift
final class MockUserDefaults: UserDefaults {
    
    convenience init() {
        self.init(suiteName: "MockUserDefaults")!
    }
    
    override init?(suiteName suitename: String?) {
        UserDefaults().removePersistentDomain(forName: suitename!)
        super.init(suiteName: suitename)
    }
    
}
```
 
