### PR TITLE
GetStoreInformationUseCaseImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -135,8 +135,8 @@
 		A821A3832B74C08600089B8F /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A821A3822B74C08600089B8F /* SplashViewModel.swift */; };
 		A82674652B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A826745C2B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift */; };
 		A82674662B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A826745E2B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift */; };
-		A82674692B8C7AD7004710CB /* MockSuccessImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82674632B8C7AD7004710CB /* MockSuccessImageRepository.swift */; };
-		A826746A2B8C7AD7004710CB /* MockFailureImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82674642B8C7AD7004710CB /* MockFailureImageRepository.swift */; };
+		A82674692B8C7AD7004710CB /* StubSuccessImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82674632B8C7AD7004710CB /* StubSuccessImageRepository.swift */; };
+		A826746A2B8C7AD7004710CB /* StubFailureImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82674642B8C7AD7004710CB /* StubFailureImageRepository.swift */; };
 		A82674862B8CF482004710CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 591A88852B384E610059E40F /* Assets.xcassets */; };
 		A826748D2B8CFA62004710CB /* FetchImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A826748C2B8CFA61004710CB /* FetchImageRepository.swift */; };
 		A826748F2B8CFA78004710CB /* FetchImageRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A826748E2B8CFA78004710CB /* FetchImageRepositoryImpl.swift */; };
@@ -209,8 +209,8 @@
 		A8E53C252B77DDF3003FCBA2 /* StoreStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C242B77DDF3003FCBA2 /* StoreStorage.swift */; };
 		A8E53C272B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C262B77F99C003FCBA2 /* GetStoresRepositoryImpl.swift */; };
 		A8E53C2B2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E53C2A2B77FA30003FCBA2 /* FetchSearchStoresRepositoryImpl.swift */; };
-		A8EC5B002B8F9B1D00D9182F /* MockFailureNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C0308E2B8E4DC800A1A6FB /* MockFailureNetworkRepository.swift */; };
-		A8EC5B012B8F9B1F00D9182F /* MockSuccessNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C030902B8E4E0A00A1A6FB /* MockSuccessNetworkRepository.swift */; };
+		A8EC5B002B8F9B1D00D9182F /* StubFailureNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C0308E2B8E4DC800A1A6FB /* StubFailureNetworkRepository.swift */; };
+		A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C030902B8E4E0A00A1A6FB /* StubSuccessNetworkRepository.swift */; };
 		A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B052B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift */; };
 		A8EC5B082B9055E300D9182F /* FakeUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B072B9055E300D9182F /* FakeUserDefaults.swift */; };
 		A8EC5B0A2B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B092B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift */; };
@@ -223,6 +223,7 @@
 		A8EC5B182B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B172B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift */; };
 		A8EC5B1A2B91C4E300D9182F /* StubGetStoresRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B192B91C4E300D9182F /* StubGetStoresRepository.swift */; };
 		A8EC5B1C2B921D9A00D9182F /* MockImage.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = A8EC5B1B2B92151A00D9182F /* MockImage.jpeg */; };
+		A8EC5B1E2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B1D2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
@@ -320,8 +321,8 @@
 		59B8865F2B6E7CF6005750EF /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		59B886612B6E8484005750EF /* UISheetPresentationController+Detent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISheetPresentationController+Detent.swift"; sourceTree = "<group>"; };
 		59B886632B6EC816005750EF /* SummaryViewHeightCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewHeightCase.swift; sourceTree = "<group>"; };
-		59C0308E2B8E4DC800A1A6FB /* MockFailureNetworkRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFailureNetworkRepository.swift; sourceTree = "<group>"; };
-		59C030902B8E4E0A00A1A6FB /* MockSuccessNetworkRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSuccessNetworkRepository.swift; sourceTree = "<group>"; };
+		59C0308E2B8E4DC800A1A6FB /* StubFailureNetworkRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailureNetworkRepository.swift; sourceTree = "<group>"; };
+		59C030902B8E4E0A00A1A6FB /* StubSuccessNetworkRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSuccessNetworkRepository.swift; sourceTree = "<group>"; };
 		59C030922B8E4E8900A1A6FB /* MockURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		59C030962B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoresRepositoryImplTests.swift; sourceTree = "<group>"; };
 		59C030982B8FB03F00A1A6FB /* FetchSearchStoresRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSearchStoresRepositoryImplTests.swift; sourceTree = "<group>"; };
@@ -376,8 +377,8 @@
 		A821A3822B74C08600089B8F /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		A826745C2B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckNetworkStatusUseCaseImplTests.swift; sourceTree = "<group>"; };
 		A826745E2B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchImageUseCaseImplTests.swift; sourceTree = "<group>"; };
-		A82674632B8C7AD7004710CB /* MockSuccessImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSuccessImageRepository.swift; sourceTree = "<group>"; };
-		A82674642B8C7AD7004710CB /* MockFailureImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFailureImageRepository.swift; sourceTree = "<group>"; };
+		A82674632B8C7AD7004710CB /* StubSuccessImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubSuccessImageRepository.swift; sourceTree = "<group>"; };
+		A82674642B8C7AD7004710CB /* StubFailureImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubFailureImageRepository.swift; sourceTree = "<group>"; };
 		A826748C2B8CFA61004710CB /* FetchImageRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchImageRepository.swift; sourceTree = "<group>"; };
 		A826748E2B8CFA78004710CB /* FetchImageRepositoryImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchImageRepositoryImpl.swift; sourceTree = "<group>"; };
 		A82674982B8D059C004710CB /* FetchImageRepositoryImplTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchImageRepositoryImplTests.swift; sourceTree = "<group>"; };
@@ -461,6 +462,7 @@
 		A8EC5B172B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRefreshStoresUseCaseImplTests.swift; sourceTree = "<group>"; };
 		A8EC5B192B91C4E300D9182F /* StubGetStoresRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubGetStoresRepository.swift; sourceTree = "<group>"; };
 		A8EC5B1B2B92151A00D9182F /* MockImage.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MockImage.jpeg; sourceTree = "<group>"; };
+		A8EC5B1D2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoreInformationUseCaseImplTests.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1051,6 +1053,7 @@
 			isa = PBXGroup;
 			children = (
 				A8EC5B172B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift */,
+				A8EC5B1D2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift */,
 				A826745C2B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift */,
 				A826745E2B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift */,
 			);
@@ -1070,10 +1073,10 @@
 		A82674602B8C7AD7004710CB /* Repository */ = {
 			isa = PBXGroup;
 			children = (
-				A82674632B8C7AD7004710CB /* MockSuccessImageRepository.swift */,
-				A82674642B8C7AD7004710CB /* MockFailureImageRepository.swift */,
-				59C0308E2B8E4DC800A1A6FB /* MockFailureNetworkRepository.swift */,
-				59C030902B8E4E0A00A1A6FB /* MockSuccessNetworkRepository.swift */,
+				A82674632B8C7AD7004710CB /* StubSuccessImageRepository.swift */,
+				A82674642B8C7AD7004710CB /* StubFailureImageRepository.swift */,
+				59C0308E2B8E4DC800A1A6FB /* StubFailureNetworkRepository.swift */,
+				59C030902B8E4E0A00A1A6FB /* StubSuccessNetworkRepository.swift */,
 				A8EC5B192B91C4E300D9182F /* StubGetStoresRepository.swift */,
 			);
 			path = Repository;
@@ -1668,7 +1671,7 @@
 				A8EC5B082B9055E300D9182F /* FakeUserDefaults.swift in Sources */,
 				592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */,
 				592D0E062B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift in Sources */,
-				A8EC5B012B8F9B1F00D9182F /* MockSuccessNetworkRepository.swift in Sources */,
+				A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */,
 				59C030992B8FB03F00A1A6FB /* FetchSearchStoresRepositoryImplTests.swift in Sources */,
 				A82674992B8D059D004710CB /* FetchImageRepositoryImplTests.swift in Sources */,
 				A8EC5B0C2B90CF0D00D9182F /* DeleteRecentSearchHistoryRepositoryImplTests.swift in Sources */,
@@ -1676,13 +1679,14 @@
 				A8EC5B162B90FE6C00D9182F /* PostNewStoreRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
 				59C030932B8E4E8900A1A6FB /* MockURLProtocol.swift in Sources */,
-				A8EC5B002B8F9B1D00D9182F /* MockFailureNetworkRepository.swift in Sources */,
-				A82674692B8C7AD7004710CB /* MockSuccessImageRepository.swift in Sources */,
+				A8EC5B002B8F9B1D00D9182F /* StubFailureNetworkRepository.swift in Sources */,
+				A82674692B8C7AD7004710CB /* StubSuccessImageRepository.swift in Sources */,
 				A8EC5B0E2B90DC2000D9182F /* DeleteAllHistoryRepositoryImplTests.swift in Sources */,
-				A826746A2B8C7AD7004710CB /* MockFailureImageRepository.swift in Sources */,
+				A826746A2B8C7AD7004710CB /* StubFailureImageRepository.swift in Sources */,
 				A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A82674652B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift in Sources */,
 				A8EC5B1A2B91C4E300D9182F /* StubGetStoresRepository.swift in Sources */,
+				A8EC5B1E2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift in Sources */,
 				59C030972B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift in Sources */,
 				A8EC5B0A2B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 			);

--- a/KCS/KCSUnitTest/TestDouble/Repository/StubFailureImageRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/StubFailureImageRepository.swift
@@ -1,5 +1,5 @@
 //
-//  MockFailureImageRepository.swift
+//  StubFailureImageRepository.swift
 //  KCSUnitTest
 //
 //  Created by 김영현 on 2/25/24.
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import Alamofire
 
-struct MockNoImageFailureImageRepository: FetchImageRepository {
+struct StubNoImageFailureImageRepository: FetchImageRepository {
     
     var cache: ImageCache
     var session: Session = Session.default
@@ -25,7 +25,7 @@ struct MockNoImageFailureImageRepository: FetchImageRepository {
     
 }
 
-struct MockAPIFailureImageRepository: FetchImageRepository {
+struct StubAPIFailureImageRepository: FetchImageRepository {
     
     var cache: ImageCache
     var session: Session = Session.default

--- a/KCS/KCSUnitTest/TestDouble/Repository/StubFailureNetworkRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/StubFailureNetworkRepository.swift
@@ -1,5 +1,5 @@
 //
-//  MockSuccessNetworkRepository.swift
+//  StubFailureNetworkRepository.swift
 //  KCSUnitTest
 //
 //  Created by 김영현 on 2/25/24.
@@ -8,10 +8,10 @@
 import Foundation
 @testable import KCS
 
-struct MockSuccessNetworkRepository: NetworkRepository {
+struct StubFailureNetworkRepository: NetworkRepository {
     
     func checkDeviceNetworkStatus() -> Bool {
-        return true
+        return false
     }
     
 }

--- a/KCS/KCSUnitTest/TestDouble/Repository/StubSuccessImageRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/StubSuccessImageRepository.swift
@@ -1,5 +1,5 @@
 //
-//  MockSuccessImageRepository.swift
+//  StubSuccessImageRepository.swift
 //  KCSUnitTest
 //
 //  Created by 김영현 on 2/25/24.
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 import RxSwift
 
-final class MockSuccessImageRepository: FetchImageRepository {
+final class StubSuccessImageRepository: FetchImageRepository {
     
     var cache: ImageCache
     var session: Session = Session.default

--- a/KCS/KCSUnitTest/TestDouble/Repository/StubSuccessNetworkRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/StubSuccessNetworkRepository.swift
@@ -1,5 +1,5 @@
 //
-//  MockFailureNetworkRepository.swift
+//  StubSuccessNetworkRepository.swift
 //  KCSUnitTest
 //
 //  Created by 김영현 on 2/25/24.
@@ -8,10 +8,10 @@
 import Foundation
 @testable import KCS
 
-struct MockFailureNetworkRepository: NetworkRepository {
+struct StubSuccessNetworkRepository: NetworkRepository {
     
     func checkDeviceNetworkStatus() -> Bool {
-        return false
+        return true
     }
     
 }

--- a/KCS/KCSUnitTest/UseCaseTest/CheckNetworkStatusUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/CheckNetworkStatusUseCaseImplTests.swift
@@ -14,14 +14,14 @@ final class CheckNetworkStatusUseCaseImplTests: XCTestCase {
     
     func test_네트워크가_안정한_경우() {
         checkNetworkStatusUseCase = CheckNetworkStatusUseCaseImpl(
-            repository: MockSuccessNetworkRepository()
+            repository: StubSuccessNetworkRepository()
         )
         XCTAssertTrue(checkNetworkStatusUseCase.execute())
     }
     
     func test_네트워크가_불안정한_경우() {
         checkNetworkStatusUseCase = CheckNetworkStatusUseCaseImpl(
-            repository: MockFailureNetworkRepository()
+            repository: StubFailureNetworkRepository()
         )
         XCTAssertFalse(checkNetworkStatusUseCase.execute())
     }

--- a/KCS/KCSUnitTest/UseCaseTest/CheckNetworkStatusUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/CheckNetworkStatusUseCaseImplTests.swift
@@ -13,16 +13,26 @@ final class CheckNetworkStatusUseCaseImplTests: XCTestCase {
     private var checkNetworkStatusUseCase: CheckNetworkStatusUseCase!
     
     func test_네트워크가_안정한_경우() {
+        // Given initial state
+        
+        // When
         checkNetworkStatusUseCase = CheckNetworkStatusUseCaseImpl(
             repository: StubSuccessNetworkRepository()
         )
+        
+        // Then
         XCTAssertTrue(checkNetworkStatusUseCase.execute())
     }
     
     func test_네트워크가_불안정한_경우() {
+        // Given initial state
+        
+        // When
         checkNetworkStatusUseCase = CheckNetworkStatusUseCaseImpl(
             repository: StubFailureNetworkRepository()
         )
+        
+        // Then
         XCTAssertFalse(checkNetworkStatusUseCase.execute())
     }
 

--- a/KCS/KCSUnitTest/UseCaseTest/FetchImageUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/FetchImageUseCaseImplTests.swift
@@ -46,7 +46,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
         let imageData = mockImage.getImageURL()
         imageCache.setImageData(imageData as NSData, for: url)
         fetchImageUseCase = FetchImageUseCaseImpl(
-            repository: MockSuccessImageRepository(
+            repository: StubSuccessImageRepository(
                 cache: imageCache
             )
         )
@@ -72,7 +72,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
         let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.noCache.rawValue
         let imageData = mockImage.getImageURL()
         fetchImageUseCase = FetchImageUseCaseImpl(
-            repository: MockSuccessImageRepository(
+            repository: StubSuccessImageRepository(
                 cache: imageCache
             )
         )
@@ -96,7 +96,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
         // Given
         let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.fail.rawValue
         fetchImageUseCase = FetchImageUseCaseImpl(
-            repository: MockNoImageFailureImageRepository(
+            repository: StubNoImageFailureImageRepository(
                 cache: imageCache
             )
         )
@@ -117,7 +117,7 @@ final class FetchImageUseCaseImplTests: XCTestCase {
         // Given
         let urlString = FetchImageUseCaseImplTestsConstant.MockURLString.fail.rawValue
         fetchImageUseCase = FetchImageUseCaseImpl(
-            repository: MockAPIFailureImageRepository(
+            repository: StubAPIFailureImageRepository(
                 cache: imageCache
             )
         )

--- a/KCS/KCSUnitTest/UseCaseTest/GetStoreInformationUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/GetStoreInformationUseCaseImplTests.swift
@@ -33,6 +33,8 @@ struct GetStoreInformationUseCaseImplTestsConstant {
         localPhotos: [""]
     )
     let storeStorage = StoreStorage()
+    let storeId: UInt = 1
+    let wrongStoreId: UInt = 2
     
 }
 
@@ -50,9 +52,10 @@ final class GetStoreInformationUseCaseImplTests: XCTestCase {
     
     func test_id가_같은_가게정보_가져오기_성공한_경우() {
         // Given initial state
+        
         // When
         do {
-            let result = try getStoreInformationUseCase.execute(tag: 1)
+            let result = try getStoreInformationUseCase.execute(tag: constant.storeId)
             // Then
             XCTAssertEqual(result, constant.store)
         } catch {
@@ -62,9 +65,10 @@ final class GetStoreInformationUseCaseImplTests: XCTestCase {
     
     func test_id가_같은_가게정보_가져오기_실패한_경우() {
         // Given initial state
+        
         // When
         do {
-            let result = try getStoreInformationUseCase.execute(tag: 2)
+            let result = try getStoreInformationUseCase.execute(tag: constant.wrongStoreId)
             // Then
             XCTFail("Error 방출 실패")
         } catch let error as StoreRepositoryError {

--- a/KCS/KCSUnitTest/UseCaseTest/GetStoreInformationUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/GetStoreInformationUseCaseImplTests.swift
@@ -1,0 +1,77 @@
+//
+//  GetStoreInformationUseCaseImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 3/2/24.
+//
+
+import XCTest
+@testable import KCS
+
+struct GetStoreInformationUseCaseImplTestsConstant {
+    
+    let store = Store(
+        id: 1,
+        title: "",
+        certificationTypes: [.goodPrice],
+        category: nil,
+        address: "",
+        phoneNumber: nil,
+        location: Location(longitude: 0, latitude: 0),
+        openingHour: [RegularOpeningHours(
+            open: BusinessHour(
+                day: .monday,
+                hour: 0,
+                minute: 0
+            ),
+            close: BusinessHour(
+                day: .monday,
+                hour: 0,
+                minute: 0
+            )
+        )],
+        localPhotos: [""]
+    )
+    let storeStorage = StoreStorage()
+    
+}
+
+final class GetStoreInformationUseCaseImplTests: XCTestCase {
+
+    private var constant: GetStoreInformationUseCaseImplTestsConstant!
+    private var repository: GetStoresRepository!
+    private var getStoreInformationUseCase: GetStoreInformationUseCaseImpl!
+    
+    override func setUp() {
+        constant = GetStoreInformationUseCaseImplTestsConstant()
+        repository = StubGetManyStoresRepository(storeStorage: constant.storeStorage)
+        getStoreInformationUseCase = GetStoreInformationUseCaseImpl(repository: repository)
+    }
+    
+    func test_id가_같은_가게정보_가져오기_성공한_경우() {
+        // Given initial state
+        // When
+        do {
+            let result = try getStoreInformationUseCase.execute(tag: 1)
+            // Then
+            XCTAssertEqual(result, constant.store)
+        } catch {
+            XCTFail("id가 같은 가게정보 가져오기 실패")
+        }
+    }
+    
+    func test_id가_같은_가게정보_가져오기_실패한_경우() {
+        // Given initial state
+        // When
+        do {
+            let result = try getStoreInformationUseCase.execute(tag: 2)
+            // Then
+            XCTFail("Error 방출 실패")
+        } catch let error as StoreRepositoryError {
+            XCTAssertEqual(error, StoreRepositoryError.wrongStoreId)
+        } catch {
+            XCTFail("Error 방출 실패")
+        }
+    }
+
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #371 

## 🚩 Summary

- GetStoreInformationUseCaseImpl 테스트 코드를 작성한다.

![image](https://github.com/Korea-Certified-Store/iOS/assets/62226667/bf80ec68-6468-48df-ad0f-4b8f243a1b74)

## 🛠️ Technical Concerns

### Stub vs Mock

현재까지 테스트를 진행하면서 테스트에 필요하지만 실제로 사용하지 않는 TestDouble의 모든 네이밍을 Mock으로 설정하고 코드를 작성하고 있었다.
그러다 문득, TestDouble에는 Mock이 아닌 다른 종류의 TestDouble도 존재하는데 과연 Mock을 잘 이해하고 적절하게 사용하고 있는 것인지에 대한 의문이 들어 팀원과 상의하고 TestDouble에 대해 알아보게 되었다.

TestDouble은 다음과 같이 5개로 분류된다.
- Dummy
- Fake
- Stub
- Mock
- Spy

이 중 헷갈렸던 내용이 바로 Stub과 Mock의 차이점이었다. 이에 대해 공부해본 결과 Stub은 **상태 검증**, Mock은 **행위 검증**을 위해 사용된다는 것을 알았다.
즉, Stub은 해당 메서드 내부에 로직에는 영향을 끼치지 않고 항상 같은 값만을 내뱉는 것이며, Mock은 내부 로직이 모두 잘 실행 되었는지를 확인하는데에 사용되는 것이었다.

우리 프로젝트 내부에서 API 통신을 대신해주는 MockURLProtocol을 제외한 TestDouble의 대부분이 Stub이었다. 따라서, Directory와 파일, 메서드의 이름을 적절하게 수정해주는 작업을 진행하였다.
