### PR TITLE
SaveRecentSearchHistoryUseCaseImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		592D0E042B8FBDD0003E90F9 /* FetchSearchStoresFailureWithWrongCertification.json in Resources */ = {isa = PBXBuildFile; fileRef = 592D0DFF2B8FB9CA003E90F9 /* FetchSearchStoresFailureWithWrongCertification.json */; };
 		592D0E062B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E052B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift */; };
 		592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */; };
+		592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */; };
+		592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */; };
 		594376342B81F071005B97B2 /* UpdateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376332B81F071005B97B2 /* UpdateRequestDTO.swift */; };
 		594376362B8201FB005B97B2 /* StoreUpdateRequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */; };
 		594376382B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */; };
@@ -256,6 +258,8 @@
 		592D0DFF2B8FB9CA003E90F9 /* FetchSearchStoresFailureWithWrongCertification.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FetchSearchStoresFailureWithWrongCertification.json; sourceTree = "<group>"; };
 		592D0E052B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepositoryImplTests.swift; sourceTree = "<group>"; };
 		592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
+		592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySaveRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
 		594376332B81F071005B97B2 /* UpdateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRequestDTO.swift; sourceTree = "<group>"; };
 		594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepository.swift; sourceTree = "<group>"; };
 		594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -1056,6 +1060,7 @@
 				A8EC5B1D2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift */,
 				A826745C2B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift */,
 				A826745E2B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift */,
+				592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */,
 			);
 			path = UseCaseTest;
 			sourceTree = "<group>";
@@ -1078,6 +1083,7 @@
 				59C0308E2B8E4DC800A1A6FB /* StubFailureNetworkRepository.swift */,
 				59C030902B8E4E0A00A1A6FB /* StubSuccessNetworkRepository.swift */,
 				A8EC5B192B91C4E300D9182F /* StubGetStoresRepository.swift */,
+				592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1669,6 +1675,7 @@
 				A826749B2B8D0BB1004710CB /* MockImage.swift in Sources */,
 				A82674662B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift in Sources */,
 				A8EC5B082B9055E300D9182F /* FakeUserDefaults.swift in Sources */,
+				592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */,
 				592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */,
 				592D0E062B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift in Sources */,
 				A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */,
@@ -1688,6 +1695,7 @@
 				A8EC5B1A2B91C4E300D9182F /* StubGetStoresRepository.swift in Sources */,
 				A8EC5B1E2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift in Sources */,
 				59C030972B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift in Sources */,
+				592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */,
 				A8EC5B0A2B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KCS/KCSUnitTest/TestDouble/Repository/SpySaveRecentSearchHistoryRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/SpySaveRecentSearchHistoryRepository.swift
@@ -1,0 +1,25 @@
+//
+//  SpySaveRecentSearchHistoryRepository.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/2/24.
+//
+
+import Foundation
+@testable import KCS
+
+final class SpySaveRecentSearchHistoryRepository: SaveRecentSearchHistoryRepository {
+    
+    let userDefaults: UserDefaults
+    let recentSearchKeywordsKey: String = "recentSearchKeywords"
+    var executeCount: Int = 0
+    
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+    
+    func saveRecentSearchHistory(recentSearchKeyword: String) {
+        self.executeCount += 1
+    }
+    
+}

--- a/KCS/KCSUnitTest/UseCaseTest/SaveRecentSearchHistoryUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/SaveRecentSearchHistoryUseCaseImplTests.swift
@@ -1,0 +1,41 @@
+//
+//  SaveRecentSearchHistoryUseCaseImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/2/24.
+//
+
+import XCTest
+@testable import KCS
+
+struct SaveRecentSearchHistoryUseCaseImplTestsConstant {
+    
+    let testKeyword = "TestKeyword"
+    let dummyUserDefaults = UserDefaults.standard
+    let resultExecuteCount = 1
+    
+}
+
+final class SaveRecentSearchHistoryUseCaseImplTests: XCTestCase {
+
+    private var saveRecentSearchHistoryUseCase: SaveRecentSearchHistoryUseCaseImpl!
+    private var spySaveRecentSearchHistoryRepository: SpySaveRecentSearchHistoryRepository!
+    private var constant: SaveRecentSearchHistoryUseCaseImplTestsConstant!
+    
+    override func setUp() {
+        constant = SaveRecentSearchHistoryUseCaseImplTestsConstant()
+        spySaveRecentSearchHistoryRepository = SpySaveRecentSearchHistoryRepository(userDefaults: constant.dummyUserDefaults)
+        saveRecentSearchHistoryUseCase = SaveRecentSearchHistoryUseCaseImpl(repository: spySaveRecentSearchHistoryRepository)
+    }
+
+    func test_Repository의_함수를_성공하는_경우() {
+        // Given initial statie
+        
+        // When
+        saveRecentSearchHistoryUseCase.execute(recentSearchKeyword: constant.testKeyword)
+        
+        // Then
+        XCTAssertEqual(spySaveRecentSearchHistoryRepository.executeCount, constant.resultExecuteCount)
+    }
+
+}

--- a/KCS/KCSUnitTest/UseCaseTest/SaveRecentSearchHistoryUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/SaveRecentSearchHistoryUseCaseImplTests.swift
@@ -11,7 +11,7 @@ import XCTest
 struct SaveRecentSearchHistoryUseCaseImplTestsConstant {
     
     let testKeyword = "TestKeyword"
-    let dummyUserDefaults = UserDefaults.standard
+    let dummyUserDefaults = UserDefaults()
     let resultExecuteCount = 1
     
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #376

## 🚩 Summary

- SaveRecentSearchHistoryUseCaseImpl 테스트

![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/5c5c075e-b203-4c0e-941d-3c81678794cb)


## 🛠️ Technical Concerns

### Spy를 이용한 테스트

가장 간단한 UseCase는 Repository의 함수 하나를 실행시키는 것 외에 로직이 없다.
그렇기 때문에 해당 UseCase의 로직을 검사할 필요가 없고, Repository의 함수 호출 여부를 검사할 수 있도록 Spy를 사용했다.
