### PR TITLE
FetchStoreIDUseCaseImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */; };
 		592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */; };
+		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
+		592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */; };
 		594376342B81F071005B97B2 /* UpdateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376332B81F071005B97B2 /* UpdateRequestDTO.swift */; };
 		594376362B8201FB005B97B2 /* StoreUpdateRequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */; };
 		594376382B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */; };
@@ -260,6 +262,8 @@
 		592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
 		592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySaveRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDRepository.swift; sourceTree = "<group>"; };
 		594376332B81F071005B97B2 /* UpdateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRequestDTO.swift; sourceTree = "<group>"; };
 		594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepository.swift; sourceTree = "<group>"; };
 		594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -1061,6 +1065,7 @@
 				A826745C2B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift */,
 				A826745E2B8C7AD7004710CB /* FetchImageUseCaseImplTests.swift */,
 				592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */,
+				592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */,
 			);
 			path = UseCaseTest;
 			sourceTree = "<group>";
@@ -1084,6 +1089,7 @@
 				59C030902B8E4E0A00A1A6FB /* StubSuccessNetworkRepository.swift */,
 				A8EC5B192B91C4E300D9182F /* StubGetStoresRepository.swift */,
 				592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */,
+				592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1678,8 +1684,10 @@
 				592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */,
 				592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */,
 				592D0E062B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift in Sources */,
+				592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */,
 				A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */,
 				59C030992B8FB03F00A1A6FB /* FetchSearchStoresRepositoryImplTests.swift in Sources */,
+				592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */,
 				A82674992B8D059D004710CB /* FetchImageRepositoryImplTests.swift in Sources */,
 				A8EC5B0C2B90CF0D00D9182F /* DeleteRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A8EC5B182B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift in Sources */,

--- a/KCS/KCSUnitTest/TestDouble/Repository/StubFetchStoreIDRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/StubFetchStoreIDRepository.swift
@@ -1,0 +1,29 @@
+//
+//  StubFetchStoreIDRepository.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/3/24.
+//
+
+import Foundation
+@testable import KCS
+
+struct StubSuccessFetchStoreIDRepository: FetchStoreIDRepository {
+    
+    var storage: StoreIDStorage
+    
+    func fetchStoreID() -> Int? {
+        return FetchStoreIDUseCaseImplTestsConstant.successStoreID
+    }
+    
+}
+
+struct StubFailureFetchStoreIDRepository: FetchStoreIDRepository {
+    
+    var storage: StoreIDStorage
+    
+    func fetchStoreID() -> Int? {
+        return FetchStoreIDUseCaseImplTestsConstant.failureStoreID
+    }
+    
+}

--- a/KCS/KCSUnitTest/UseCaseTest/FetchStoreIDUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/FetchStoreIDUseCaseImplTests.swift
@@ -10,7 +10,6 @@ import XCTest
 
 struct FetchStoreIDUseCaseImplTestsConstant {
     
-    let testKeyword = "TestKeyword"
     let dummyStoreIDStorage = StoreIDStorage()
     static let successStoreID = 1
     static let failureStoreID: Int? = nil

--- a/KCS/KCSUnitTest/UseCaseTest/FetchStoreIDUseCaseImplTests.swift
+++ b/KCS/KCSUnitTest/UseCaseTest/FetchStoreIDUseCaseImplTests.swift
@@ -1,0 +1,55 @@
+//
+//  FetchStoreIDUseCaseImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/3/24.
+//
+
+import XCTest
+@testable import KCS
+
+struct FetchStoreIDUseCaseImplTestsConstant {
+    
+    let testKeyword = "TestKeyword"
+    let dummyStoreIDStorage = StoreIDStorage()
+    static let successStoreID = 1
+    static let failureStoreID: Int? = nil
+    
+}
+
+final class FetchStoreIDUseCaseImplTests: XCTestCase {
+
+    private var fetchStoreIDUseCase: FetchStoreIDUseCaseImpl!
+    private var constant: FetchStoreIDUseCaseImplTestsConstant!
+    private var stubSuccessFetchStoreIDRepository: StubSuccessFetchStoreIDRepository!
+    private var stubFailureFetchStoreIDRepository: StubFailureFetchStoreIDRepository!
+    
+    override func setUp() {
+        constant = FetchStoreIDUseCaseImplTestsConstant()
+        stubSuccessFetchStoreIDRepository = StubSuccessFetchStoreIDRepository(storage: constant.dummyStoreIDStorage)
+        stubFailureFetchStoreIDRepository = StubFailureFetchStoreIDRepository(storage: constant.dummyStoreIDStorage)
+    }
+    
+    func test_ID를_가져오는_것에_성공한_경우() {
+        // Given
+        fetchStoreIDUseCase = FetchStoreIDUseCaseImpl(repository: stubSuccessFetchStoreIDRepository)
+        
+        // When
+        let result = fetchStoreIDUseCase.execute()
+        
+        // Then
+        XCTAssertEqual(result, FetchStoreIDUseCaseImplTestsConstant.successStoreID)
+    }
+    
+    func test_ID를_가져오는_것에_실패한_경우() {
+        // Given
+        fetchStoreIDUseCase = FetchStoreIDUseCaseImpl(repository: stubFailureFetchStoreIDRepository)
+        
+        // When
+        let result = fetchStoreIDUseCase.execute()
+        
+        // Then
+        XCTAssertEqual(result, FetchStoreIDUseCaseImplTestsConstant.failureStoreID)
+    }
+
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #383

## 🚩 Summary

- FetchStoreIDUseCaseImpl 테스트

![image](https://github.com/Korea-Certified-Store/iOS/assets/128480641/11eba106-ebb8-4b16-8180-65bdc04a854c)

## 🛠️ Technical Concerns

### Test Double에서 사용할 상수

Test Double에서 사용할 상수를 Magic Number로 진행하는 것을 방지하기 위해서 Constant에서 static 변수로 선언하여 사용했다.

```swift
struct FetchStoreIDUseCaseImplTestsConstant {
    
    let dummyStoreIDStorage = StoreIDStorage()
    static let successStoreID = 1
    static let failureStoreID: Int? = nil
    
}

struct StubSuccessFetchStoreIDRepository: FetchStoreIDRepository {
    
    var storage: StoreIDStorage
    
    func fetchStoreID() -> Int? {
        return FetchStoreIDUseCaseImplTestsConstant.successStoreID
    }
    
}

struct StubFailureFetchStoreIDRepository: FetchStoreIDRepository {
    
    var storage: StoreIDStorage
    
    func fetchStoreID() -> Int? {
        return FetchStoreIDUseCaseImplTestsConstant.failureStoreID
    }
    
}

```
