### PR TITLE
NewStoreRequestViewModelImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -23,12 +23,12 @@
 		592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */; };
 		592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */; };
-		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
-		592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */; };
-		592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */; };
-		592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */; };
 		592D0E142B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E162B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */; };
+		592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */; };
+		592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */; };
+		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
+		592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */; };
 		594376342B81F071005B97B2 /* UpdateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376332B81F071005B97B2 /* UpdateRequestDTO.swift */; };
 		594376362B8201FB005B97B2 /* StoreUpdateRequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */; };
 		594376382B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */; };
@@ -238,6 +238,9 @@
 		A8EC5B262B947E6800D9182F /* SetStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B252B947E6800D9182F /* SetStoreIDRepository.swift */; };
 		A8EC5B282B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B272B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift */; };
 		A8EC5B2A2B9483D600D9182F /* SpySetStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B292B9483D600D9182F /* SpySetStoreIDRepository.swift */; };
+		A8EC5B2D2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */; };
+		A8EC5B302B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */; };
+		A8EC5B322B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
@@ -272,12 +275,12 @@
 		592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
 		592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySaveRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
-		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
-		592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDRepository.swift; sourceTree = "<group>"; };
-		592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
-		592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
 		592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySpyDeleteRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDRepository.swift; sourceTree = "<group>"; };
 		594376332B81F071005B97B2 /* UpdateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRequestDTO.swift; sourceTree = "<group>"; };
 		594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepository.swift; sourceTree = "<group>"; };
 		594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -491,6 +494,9 @@
 		A8EC5B252B947E6800D9182F /* SetStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetStoreIDRepository.swift; sourceTree = "<group>"; };
 		A8EC5B272B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
 		A8EC5B292B9483D600D9182F /* SpySetStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySetStoreIDRepository.swift; sourceTree = "<group>"; };
+		A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestViewModelImplTests.swift; sourceTree = "<group>"; };
+		A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSuccessPostNewStoreUseCase.swift; sourceTree = "<group>"; };
+		A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailurePostNewStoreUseCase.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -751,6 +757,7 @@
 			children = (
 				594376932B8C7E5C005B97B2 /* RepositoryTest */,
 				A826745A2B8C7AD7004710CB /* UseCaseTest */,
+				A8EC5B2B2B95F6E400D9182F /* ViewModelTest */,
 				A826745F2B8C7AD7004710CB /* TestDouble */,
 			);
 			path = KCSUnitTest;
@@ -1099,6 +1106,7 @@
 		A826745F2B8C7AD7004710CB /* TestDouble */ = {
 			isa = PBXGroup;
 			children = (
+				A8EC5B2E2B95FC9F00D9182F /* UseCase */,
 				A82674602B8C7AD7004710CB /* Repository */,
 				A82674912B8CFD61004710CB /* MockServer */,
 				A82674892B8CF6DF004710CB /* Resource */,
@@ -1257,6 +1265,23 @@
 				A8ACB7EC2B59647400540BD1 /* OpeningHourError.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		A8EC5B2B2B95F6E400D9182F /* ViewModelTest */ = {
+			isa = PBXGroup;
+			children = (
+				A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */,
+			);
+			path = ViewModelTest;
+			sourceTree = "<group>";
+		};
+		A8EC5B2E2B95FC9F00D9182F /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */,
+				A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */,
+			);
+			path = UseCase;
 			sourceTree = "<group>";
 		};
 		E99F20FF9A30DCF9C51285A2 /* Frameworks */ = {
@@ -1721,6 +1746,7 @@
 				592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */,
 				A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */,
 				592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */,
+				A8EC5B2D2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift in Sources */,
 				59C030992B8FB03F00A1A6FB /* FetchSearchStoresRepositoryImplTests.swift in Sources */,
 				592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */,
 				A8EC5B202B9348EC00D9182F /* GetOpenClosedUseCaseImplTests.swift in Sources */,
@@ -1728,8 +1754,10 @@
 				A8EC5B0C2B90CF0D00D9182F /* DeleteRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A8EC5B182B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift in Sources */,
 				592D0E142B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift in Sources */,
+				A8EC5B322B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift in Sources */,
 				A8EC5B162B90FE6C00D9182F /* PostNewStoreRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
+				A8EC5B302B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift in Sources */,
 				59C030932B8E4E8900A1A6FB /* MockURLProtocol.swift in Sources */,
 				A8EC5B002B8F9B1D00D9182F /* StubFailureNetworkRepository.swift in Sources */,
 				A82674692B8C7AD7004710CB /* StubSuccessImageRepository.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -189,6 +189,8 @@
 		A890870A2B4EF00B00767225 /* SystemImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89087092B4EF00B00767225 /* SystemImage.swift */; };
 		A890870D2B4EF91600767225 /* UIView+SetLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870C2B4EF91600767225 /* UIView+SetLayer.swift */; };
 		A890870F2B4F836C00767225 /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890870E2B4F836C00767225 /* SummaryView.swift */; };
+		A8A779172B98A56F00237881 /* StubFailurePostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A779152B98A56F00237881 /* StubFailurePostNewStoreUseCase.swift */; };
+		A8A779182B98A56F00237881 /* StubSuccessPostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A779162B98A56F00237881 /* StubSuccessPostNewStoreUseCase.swift */; };
 		A8A7E05B2B642EC900D015E5 /* DetailViewContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A7E05A2B642EC900D015E5 /* DetailViewContents.swift */; };
 		A8A7E05D2B64AF1300D015E5 /* StoreInformationViewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A7E05C2B64AF1200D015E5 /* StoreInformationViewConstraints.swift */; };
 		A8A7E0602B64E62200D015E5 /* NMFMyPosition+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A7E05F2B64E62200D015E5 /* NMFMyPosition+.swift */; };
@@ -245,8 +247,6 @@
 		A8EC5B282B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B272B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift */; };
 		A8EC5B2A2B9483D600D9182F /* SpySetStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B292B9483D600D9182F /* SpySetStoreIDRepository.swift */; };
 		A8EC5B2D2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */; };
-		A8EC5B302B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */; };
-		A8EC5B322B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */; };
 		A8EC5B342B9767FD00D9182F /* NewStoreRequestInputCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B332B9767FD00D9182F /* NewStoreRequestInputCase.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
@@ -454,6 +454,8 @@
 		A89087092B4EF00B00767225 /* SystemImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImage.swift; sourceTree = "<group>"; };
 		A890870C2B4EF91600767225 /* UIView+SetLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SetLayer.swift"; sourceTree = "<group>"; };
 		A890870E2B4F836C00767225 /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
+		A8A779152B98A56F00237881 /* StubFailurePostNewStoreUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubFailurePostNewStoreUseCase.swift; sourceTree = "<group>"; };
+		A8A779162B98A56F00237881 /* StubSuccessPostNewStoreUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubSuccessPostNewStoreUseCase.swift; sourceTree = "<group>"; };
 		A8A7E05A2B642EC900D015E5 /* DetailViewContents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewContents.swift; sourceTree = "<group>"; };
 		A8A7E05C2B64AF1200D015E5 /* StoreInformationViewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInformationViewConstraints.swift; sourceTree = "<group>"; };
 		A8A7E05F2B64E62200D015E5 /* NMFMyPosition+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NMFMyPosition+.swift"; sourceTree = "<group>"; };
@@ -508,8 +510,6 @@
 		A8EC5B272B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
 		A8EC5B292B9483D600D9182F /* SpySetStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySetStoreIDRepository.swift; sourceTree = "<group>"; };
 		A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestViewModelImplTests.swift; sourceTree = "<group>"; };
-		A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSuccessPostNewStoreUseCase.swift; sourceTree = "<group>"; };
-		A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailurePostNewStoreUseCase.swift; sourceTree = "<group>"; };
 		A8EC5B332B9767FD00D9182F /* NewStoreRequestInputCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestInputCase.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -545,6 +545,7 @@
 				591A887A2B384E600059E40F /* Products */,
 				ED50AD730FA5F4D533F6DF5F /* Pods */,
 				E99F20FF9A30DCF9C51285A2 /* Frameworks */,
+				A8A779142B98A50F00237881 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -598,14 +599,6 @@
 			path = RepositoryTest;
 			sourceTree = "<group>";
 		};
-		59491D7B2B9751210009E77F /* ViewModelTest */ = {
-			isa = PBXGroup;
-			children = (
-				59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */,
-			);
-			path = ViewModelTest;
-			sourceTree = "<group>";
-		};
 		59491D7E2B9752410009E77F /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
@@ -614,8 +607,8 @@
 				59491D872B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift */,
 				59491D832B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift */,
 				59491D852B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift */,
-        59491D852B9785080009E77F /* StubSuccessPostNewStoreUseCase.swift */,
-				59491D852B9785080009E77F /* StubFailurePostNewStoreUseCase.swift */,
+				A8A779162B98A56F00237881 /* StubSuccessPostNewStoreUseCase.swift */,
+				A8A779152B98A56F00237881 /* StubFailurePostNewStoreUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -791,7 +784,6 @@
 		5977BE8B2B5966F900725C90 /* KCSUnitTest */ = {
 			isa = PBXGroup;
 			children = (
-				59491D7B2B9751210009E77F /* ViewModelTest */,
 				594376932B8C7E5C005B97B2 /* RepositoryTest */,
 				A826745A2B8C7AD7004710CB /* UseCaseTest */,
 				A8EC5B2B2B95F6E400D9182F /* ViewModelTest */,
@@ -1308,6 +1300,7 @@
 		A8EC5B2B2B95F6E400D9182F /* ViewModelTest */ = {
 			isa = PBXGroup;
 			children = (
+				59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */,
 				A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */,
 			);
 			path = ViewModelTest;
@@ -1784,10 +1777,8 @@
 				A8EC5B0C2B90CF0D00D9182F /* DeleteRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A8EC5B182B91C3CB00D9182F /* GetRefreshStoresUseCaseImplTests.swift in Sources */,
 				592D0E142B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift in Sources */,
-				A8EC5B322B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift in Sources */,
 				A8EC5B162B90FE6C00D9182F /* PostNewStoreRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
-				A8EC5B302B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift in Sources */,
 				59C030932B8E4E8900A1A6FB /* MockURLProtocol.swift in Sources */,
 				59491D882B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift in Sources */,
 				59491D842B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift in Sources */,
@@ -1796,6 +1787,7 @@
 				A8EC5B0E2B90DC2000D9182F /* DeleteAllHistoryRepositoryImplTests.swift in Sources */,
 				A826746A2B8C7AD7004710CB /* StubFailureImageRepository.swift in Sources */,
 				A8EC5B282B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift in Sources */,
+				A8A779182B98A56F00237881 /* StubSuccessPostNewStoreUseCase.swift in Sources */,
 				59491D802B9752510009E77F /* SpySetStoreIDUseCase.swift in Sources */,
 				59491D822B9753EF0009E77F /* StubFetchStoreIDUseCase.swift in Sources */,
 				A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */,
@@ -1805,6 +1797,7 @@
 				A8EC5B1E2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift in Sources */,
 				59C030972B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift in Sources */,
 				592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */,
+				A8A779172B98A56F00237881 /* StubFailurePostNewStoreUseCase.swift in Sources */,
 				59491D862B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift in Sources */,
 				592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */,
 				59491D7D2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift in Sources */,

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		A8EC5B2D2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */; };
 		A8EC5B302B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */; };
 		A8EC5B322B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */; };
+		A8EC5B342B9767FD00D9182F /* NewStoreRequestInputCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EC5B332B9767FD00D9182F /* NewStoreRequestInputCase.swift */; };
 		AE60727C9A543E3D0F3A0279 /* Pods_KCSUnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71A6818C1431365A23C873FB /* Pods_KCSUnitTest.framework */; };
 		BBE1483137890D1D37D0E308 /* Pods_KCS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A3902FBE673069073F47D82 /* Pods_KCS.framework */; };
 /* End PBXBuildFile section */
@@ -497,6 +498,7 @@
 		A8EC5B2C2B95F71800D9182F /* NewStoreRequestViewModelImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestViewModelImplTests.swift; sourceTree = "<group>"; };
 		A8EC5B2F2B95FD1A00D9182F /* StubSuccessPostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSuccessPostNewStoreUseCase.swift; sourceTree = "<group>"; };
 		A8EC5B312B97610D00D9182F /* StubFailurePostNewStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailurePostNewStoreUseCase.swift; sourceTree = "<group>"; };
+		A8EC5B332B9767FD00D9182F /* NewStoreRequestInputCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewStoreRequestInputCase.swift; sourceTree = "<group>"; };
 		D7B848B1C5D2F1B31C605818 /* Pods-KCSUnitTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KCSUnitTest.debug.xcconfig"; path = "Target Support Files/Pods-KCSUnitTest/Pods-KCSUnitTest.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -969,6 +971,7 @@
 				A8AF06822B8281C200E73574 /* RequestNewStoreCertificationIsSelected.swift */,
 				5943764F2B82437C005B97B2 /* StoreUpdateRequestType.swift */,
 				A8AE14C52B86460F00A554A8 /* AutoCompletionKeyword.swift */,
+				A8EC5B332B9767FD00D9182F /* NewStoreRequestInputCase.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1669,6 +1672,7 @@
 				A8AE14C82B8784FD00A554A8 /* SaveRecentSearchHistoryRepositoryImpl.swift in Sources */,
 				A85659522B83C6DC00775C78 /* StoreListDependency.swift in Sources */,
 				A8722EFE2B7644D7001ED988 /* FetchRecentSearchHistoryUseCaseImpl.swift in Sources */,
+				A8EC5B342B9767FD00D9182F /* NewStoreRequestInputCase.swift in Sources */,
 				59503A822B80ED340006CF35 /* StoreUpdateRequestViewModelImpl.swift in Sources */,
 				59B8865A2B6E3B40005750EF /* StoreInformationViewController.swift in Sources */,
 				A81B5A682B7C81DB0042307A /* DeleteAllHistoryUseCase.swift in Sources */,

--- a/KCS/KCS/Domain/Entity/NewStoreRequestInputCase.swift
+++ b/KCS/KCS/Domain/Entity/NewStoreRequestInputCase.swift
@@ -1,0 +1,16 @@
+//
+//  NewStoreRequestInputCase.swift
+//  KCS
+//
+//  Created by 김영현 on 3/5/24.
+//
+
+import Foundation
+
+enum InputCase {
+    
+    case title
+    case address
+    case detailAddress
+    
+}

--- a/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreRequestViewController.swift
+++ b/KCS/KCS/Presentation/NewStoreRequest/View/NewStoreRequestViewController.swift
@@ -107,7 +107,7 @@ final class NewStoreRequestViewController: UIViewController {
         textField.rx.controlEvent([.editingDidEnd])
             .asObservable()
             .bind { [weak self] _ in
-                self?.viewModel.action(input: .titleEndEdit(text: textField.text ?? ""))
+                self?.viewModel.action(input: .endEdit(text: textField.text ?? "", inputCase: .title))
             }
             .disposed(by: disposeBag)
         
@@ -188,7 +188,7 @@ final class NewStoreRequestViewController: UIViewController {
         textField.rx.controlEvent([.editingDidEnd])
             .asObservable()
             .bind { [weak self] _ in
-                self?.viewModel.action(input: .detailAddressEndEdit(text: textField.text ?? ""))
+                self?.viewModel.action(input: .endEdit(text: textField.text ?? "", inputCase: .detailAddress))
             }
             .disposed(by: disposeBag)
         
@@ -379,7 +379,7 @@ private extension NewStoreRequestViewController {
             .orEmpty
             .distinctUntilChanged()
             .bind { [weak self] text in
-                self?.viewModel.action(input: .titleWhileEdit(text: text))
+                self?.viewModel.action(input: .whileEdit(text: text, inputCase: .title))
             }
             .disposed(by: disposeBag)
         
@@ -387,7 +387,7 @@ private extension NewStoreRequestViewController {
             .orEmpty
             .distinctUntilChanged()
             .bind { [weak self] text in
-                self?.viewModel.action(input: .detailAddressWhileEdit(text: text))
+                self?.viewModel.action(input: .whileEdit(text: text, inputCase: .detailAddress))
             }
             .disposed(by: disposeBag)
     }
@@ -404,7 +404,7 @@ private extension NewStoreRequestViewController {
         addressObserver
             .bind { [weak self] address in
                 self?.addressTextField.text = address
-                self?.viewModel.action(input: .addressEndEdit(text: address))
+                self?.viewModel.action(input: .endEdit(text: address, inputCase: .address))
             }
             .disposed(by: disposeBag)
     }
@@ -670,7 +670,7 @@ private extension NewStoreRequestViewController {
     func presentAddressView() {
         let addressViewController = AddressViewController(addressObserver: addressObserver)
         present(addressViewController, animated: true) { [weak self] in
-            self?.viewModel.action(input: .addressEndEdit(text: self?.addressTextField.text ?? ""))
+            self?.viewModel.action(input: .endEdit(text: self?.addressTextField.text ?? "", inputCase: .address))
         }
     }
     

--- a/KCS/KCS/Presentation/NewStoreRequest/ViewModel/NewStoreRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/NewStoreRequest/ViewModel/NewStoreRequestViewModelImpl.swift
@@ -37,16 +37,10 @@ final class NewStoreRequestViewModelImpl: NewStoreRequestViewModel {
     
     func action(input: NewStoreRequestViewModelInputCase) {
         switch input {
-        case .titleWhileEdit(let text):
-            whileEdit(text: text, inputCase: .title)
-        case .titleEndEdit(let text):
-            editEnd(text: text, inputCase: .title)
-        case .addressEndEdit(let text):
-            editEnd(text: text, inputCase: .address)
-        case .detailAddressWhileEdit(let text):
-            whileEdit(text: text, inputCase: .detailAddress)
-        case .detailAddressEndEdit(let text):
-            editEnd(text: text, inputCase: .detailAddress)
+        case .whileEdit(let text, let inputCase):
+            whileEdit(text: text, inputCase: inputCase)
+        case .endEdit(let text, let inputCase):
+            editEnd(text: text, inputCase: inputCase)
         case .certificationEndEdit(let requestNewStoreCertificationIsSelected):
             certificationEditEnd(requestNewStoreCertificationIsSelected: requestNewStoreCertificationIsSelected)
         case .completeButtonTapped(let storeName, let address, let certifications):
@@ -57,12 +51,6 @@ final class NewStoreRequestViewModelImpl: NewStoreRequestViewModel {
 }
 
 private extension NewStoreRequestViewModelImpl {
-    
-    enum InputCase {
-        case title
-        case address
-        case detailAddress
-    }
     
     func whileEdit(text: String, inputCase: InputCase) {
         if text.isEmpty {

--- a/KCS/KCS/Presentation/NewStoreRequest/ViewModel/Protocol/NewStoreRequestViewModel.swift
+++ b/KCS/KCS/Presentation/NewStoreRequest/ViewModel/Protocol/NewStoreRequestViewModel.swift
@@ -22,11 +22,8 @@ protocol NewStoreRequestViewModelInput {
 
 enum NewStoreRequestViewModelInputCase {
     
-    case titleWhileEdit(text: String)
-    case titleEndEdit(text: String)
-    case addressEndEdit(text: String)
-    case detailAddressWhileEdit(text: String)
-    case detailAddressEndEdit(text: String)
+    case whileEdit(text: String, inputCase: InputCase)
+    case endEdit(text: String, inputCase: InputCase)
     case certificationEndEdit(requestNewStoreCertificationIsSelected: RequestNewStoreCertificationIsSelected)
     case completeButtonTapped(storeName: String, address: String, certifications: RequestNewStoreCertificationIsSelected)
     

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubFailurePostNewStoreUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubFailurePostNewStoreUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 struct StubServerFailurePostNewStoreUseCase: PostNewStoreUseCase {
     
-    var repository: PostNewStoreRepository
+    let repository: PostNewStoreRepository
     
     func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
@@ -23,7 +23,7 @@ struct StubServerFailurePostNewStoreUseCase: PostNewStoreUseCase {
 
 struct StubClientFailurePostNewStoreUseCase: PostNewStoreUseCase {
     
-    var repository: PostNewStoreRepository
+    let repository: PostNewStoreRepository
     
     func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
         return Observable.create { observer -> Disposable in

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubFailurePostNewStoreUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubFailurePostNewStoreUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  StubFailurePostNewStoreUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 3/5/24.
+//
+
+@testable import KCS
+import RxSwift
+
+struct StubServerFailurePostNewStoreUseCase: PostNewStoreUseCase {
+    
+    var repository: PostNewStoreRepository
+    
+    func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(ErrorAlertMessage.server)
+            return Disposables.create()
+        }
+    }
+    
+}
+
+struct StubClientFailurePostNewStoreUseCase: PostNewStoreUseCase {
+    
+    var repository: PostNewStoreRepository
+    
+    func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(NetworkError.wrongURL)
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessPostNewStoreUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessPostNewStoreUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  StubSuccessPostNewStoreUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 3/4/24.
+//
+
+@testable import KCS
+import RxSwift
+
+struct StubSuccessPostNewStoreUseCase: PostNewStoreUseCase {
+    
+    var repository: PostNewStoreRepository
+    
+    func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onNext(())
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessPostNewStoreUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessPostNewStoreUseCase.swift
@@ -10,13 +10,10 @@ import RxSwift
 
 struct StubSuccessPostNewStoreUseCase: PostNewStoreUseCase {
     
-    var repository: PostNewStoreRepository
+    let repository: PostNewStoreRepository
     
     func execute(storeName: String, formattedAddress: String, certifications: [CertificationType]) -> Observable<Void> {
-        return Observable.create { observer -> Disposable in
-            observer.onNext(())
-            return Disposables.create()
-        }
+        return .just(())
     }
     
 }

--- a/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
+++ b/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
@@ -53,7 +53,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleEndEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.emptyTestText, inputCase: .title))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -67,7 +67,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .title))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -81,7 +81,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.emptyTestText, inputCase: .address))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -95,7 +95,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .address))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -109,7 +109,10 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .detailAddressEndEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .endEdit(
+            text: constant.emptyTestText,
+            inputCase: .detailAddress
+        ))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -123,7 +126,10 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .detailAddressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .endEdit(
+            text: constant.testText,
+            inputCase: .detailAddress
+        ))
         
         // Then
         XCTAssertNotNil(observer.events.first)
@@ -169,9 +175,9 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .title))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .detailAddress))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .address))
         newStoreRequestViewModel.action(input: .certificationEndEdit(
             requestNewStoreCertificationIsSelected: constant.certificationSelected
         ))
@@ -193,9 +199,9 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.emptyTestText))
-        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.emptyTestText, inputCase: .title))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .detailAddress))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .address))
         newStoreRequestViewModel.action(input: .certificationEndEdit(
             requestNewStoreCertificationIsSelected: constant.certificationSelected
         ))
@@ -217,9 +223,9 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .title))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .detailAddress))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.emptyTestText, inputCase: .address))
         newStoreRequestViewModel.action(input: .certificationEndEdit(
             requestNewStoreCertificationIsSelected: constant.certificationSelected
         ))
@@ -241,9 +247,9 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.emptyTestText))
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .title))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.emptyTestText, inputCase: .detailAddress))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .address))
         newStoreRequestViewModel.action(input: .certificationEndEdit(
             requestNewStoreCertificationIsSelected: constant.certificationSelected
         ))
@@ -265,9 +271,9 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
             .disposed(by: disposeBag)
         
         // When
-        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
-        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.emptyTestText))
-        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.testText, inputCase: .title))
+        newStoreRequestViewModel.action(input: .whileEdit(text: constant.emptyTestText, inputCase: .detailAddress))
+        newStoreRequestViewModel.action(input: .endEdit(text: constant.testText, inputCase: .address))
         newStoreRequestViewModel.action(input: .certificationEndEdit(
             requestNewStoreCertificationIsSelected: constant.emptyCertificationSelected
         ))

--- a/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
+++ b/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
@@ -1,0 +1,373 @@
+//
+//  NewStoreRequestViewModelImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 김영현 on 3/4/24.
+//
+
+import XCTest
+@testable import KCS
+import Alamofire
+import RxSwift
+import RxTest
+
+struct NewStoreRequestViewModelImplTestConstant {
+    
+    let dummyRepository = PostNewStoreRepositoryImpl(session: Session())
+    let emptyTestText = ""
+    let testText = "Test"
+    let emptyCertificationSelected = RequestNewStoreCertificationIsSelected()
+    let certificationSelected = RequestNewStoreCertificationIsSelected(goodPrice: true)
+    
+}
+
+final class NewStoreRequestViewModelImplTests: XCTestCase {
+    
+    private var constant: NewStoreRequestViewModelImplTestConstant!
+    private var postNewStoreUseCase: PostNewStoreUseCase!
+    private var dependency: NewStoreRequestDependency!
+    private var newStoreRequestViewModel: NewStoreRequestViewModelImpl!
+    private var scheduler: TestScheduler!
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        scheduler = TestScheduler(initialClock: 0)
+        disposeBag = DisposeBag()
+        constant = NewStoreRequestViewModelImplTestConstant()
+        postNewStoreUseCase = StubSuccessPostNewStoreUseCase(
+            repository: constant.dummyRepository
+        )
+        dependency = NewStoreRequestDependency(
+            postNewStoreUseCase: postNewStoreUseCase
+        )
+        newStoreRequestViewModel = NewStoreRequestViewModelImpl(
+            dependency: dependency
+        )
+    }
+    
+    func test_제목_칸이_빈칸인_채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.titleWarningOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleEndEdit(text: constant.emptyTestText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_제목_칸이_빈칸이_아닌채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.titleEndEditOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleEndEdit(text: constant.testText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_주소_칸이_빈칸인_채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.addressWarningOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.emptyTestText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_주소_칸이_빈칸이_아닌채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.addressEndEditOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_상세_주소_칸이_빈칸인_채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.detailAddressWarningOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .detailAddressEndEdit(text: constant.emptyTestText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_상세_주소_칸이_빈칸이_아닌채로_수정을_마친_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.detailAddressEndEditOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .detailAddressEndEdit(text: constant.testText))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_인증제_버튼이_아무것도_활성화_되지_않은_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.certificationWarningOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.emptyCertificationSelected
+        ))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_인증제_버튼이_하나라도_활성화된_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.certificationEndEditOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.certificationSelected
+        ))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_네비게이션바_상단_완료_버튼이_활성화_된_경우() {
+        // Given
+        let observer = scheduler.createObserver(Bool.self)
+        newStoreRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.certificationSelected
+        ))
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertTrue(result)
+        } else {
+            XCTFail("완료 버튼 활성화 실패")
+        }
+    }
+    
+    func test_제목란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
+        // Given
+        let observer = scheduler.createObserver(Bool.self)
+        newStoreRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.certificationSelected
+        ))
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertFalse(result)
+        } else {
+            XCTFail("완료 버튼 비활성화 실패")
+        }
+    }
+    
+    func test_주소란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
+        // Given
+        let observer = scheduler.createObserver(Bool.self)
+        newStoreRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.certificationSelected
+        ))
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertFalse(result)
+        } else {
+            XCTFail("완료 버튼 비활성화 실패")
+        }
+    }
+    
+    func test_상세주소란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
+        // Given
+        let observer = scheduler.createObserver(Bool.self)
+        newStoreRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.certificationSelected
+        ))
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertFalse(result)
+        } else {
+            XCTFail("완료 버튼 비활성화 실패")
+        }
+    }
+    
+    func test_활성화된_인증제_버튼이_없기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
+        // Given
+        let observer = scheduler.createObserver(Bool.self)
+        newStoreRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(input: .titleWhileEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .detailAddressWhileEdit(text: constant.emptyTestText))
+        newStoreRequestViewModel.action(input: .addressEndEdit(text: constant.testText))
+        newStoreRequestViewModel.action(input: .certificationEndEdit(
+            requestNewStoreCertificationIsSelected: constant.emptyCertificationSelected
+        ))
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertFalse(result)
+        } else {
+            XCTFail("완료 버튼 비활성화 실패")
+        }
+    }
+    
+    func test_완료버튼을_누르고_서버에_정상적으로_POST_된_경우() {
+        // Given
+        let observer = scheduler.createObserver(Void.self)
+        newStoreRequestViewModel.completePostNewStoreOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(
+            input: .completeButtonTapped(
+                storeName: constant.testText,
+                address: constant.testText,
+                certifications: constant.certificationSelected
+            )
+        )
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_완료버튼을_누르고_서버_에러로_POST실패한_경우() {
+        // Given
+        postNewStoreUseCase = StubServerFailurePostNewStoreUseCase(
+            repository: constant.dummyRepository
+        )
+        dependency = NewStoreRequestDependency(
+            postNewStoreUseCase: postNewStoreUseCase
+        )
+        newStoreRequestViewModel = NewStoreRequestViewModelImpl(
+            dependency: dependency
+        )
+        let observer = scheduler.createObserver(ErrorAlertMessage.self)
+        newStoreRequestViewModel.errorAlertOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(
+            input: .completeButtonTapped(
+                storeName: constant.testText,
+                address: constant.testText,
+                certifications: constant.certificationSelected
+            )
+        )
+        
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertEqual(result, ErrorAlertMessage.server)
+        } else {
+            XCTFail("ErrorAlertMessage 방출 실패")
+        }
+    }
+    
+    func test_완료버튼을_누르고_알_수_없는_에러로_POST실패한_경우() {
+        // Given
+        postNewStoreUseCase = StubClientFailurePostNewStoreUseCase(
+            repository: constant.dummyRepository
+        )
+        dependency = NewStoreRequestDependency(
+            postNewStoreUseCase: postNewStoreUseCase
+        )
+        newStoreRequestViewModel = NewStoreRequestViewModelImpl(
+            dependency: dependency
+        )
+        let observer = scheduler.createObserver(ErrorAlertMessage.self)
+        newStoreRequestViewModel.errorAlertOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        newStoreRequestViewModel.action(
+            input: .completeButtonTapped(
+                storeName: constant.testText,
+                address: constant.testText,
+                certifications: constant.certificationSelected
+            )
+        )
+        
+        // Then
+        // Then
+        if let observerResult = observer.events.first,
+           let result = observerResult.value.element {
+            XCTAssertEqual(result, ErrorAlertMessage.client)
+        } else {
+            XCTFail("ErrorAlertMessage 방출 실패")
+        }
+    }
+    
+}

--- a/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
+++ b/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
@@ -183,12 +183,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         ))
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertTrue(result)
-        } else {
-            XCTFail("완료 버튼 활성화 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, true)
     }
     
     func test_제목란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
@@ -207,12 +202,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         ))
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertFalse(result)
-        } else {
-            XCTFail("완료 버튼 비활성화 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, false)
     }
     
     func test_주소란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
@@ -231,12 +221,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         ))
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertFalse(result)
-        } else {
-            XCTFail("완료 버튼 비활성화 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, false)
     }
     
     func test_상세주소란이_빈칸이기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
@@ -255,12 +240,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         ))
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertFalse(result)
-        } else {
-            XCTFail("완료 버튼 비활성화 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, false)
     }
     
     func test_활성화된_인증제_버튼이_없기_때문에_네비게이션바_상단_완료_버튼이_활성화되지_않은_경우() {
@@ -279,12 +259,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         ))
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertFalse(result)
-        } else {
-            XCTFail("완료 버튼 비활성화 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, false)
     }
     
     func test_완료버튼을_누르고_서버에_정상적으로_POST_된_경우() {
@@ -333,12 +308,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         )
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertEqual(result, ErrorAlertMessage.server)
-        } else {
-            XCTFail("ErrorAlertMessage 방출 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, ErrorAlertMessage.server)
     }
     
     func test_완료버튼을_누르고_알_수_없는_에러로_POST실패한_경우() {
@@ -367,12 +337,7 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         )
         
         // Then
-        if let observerResult = observer.events.first,
-           let result = observerResult.value.element {
-            XCTAssertEqual(result, ErrorAlertMessage.client)
-        } else {
-            XCTFail("ErrorAlertMessage 방출 실패")
-        }
+        XCTAssertEqual(observer.events.first?.value.element, ErrorAlertMessage.client)
     }
     
 }

--- a/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
+++ b/KCS/KCSUnitTest/ViewModelTest/NewStoreRequestViewModelImplTests.swift
@@ -367,7 +367,6 @@ final class NewStoreRequestViewModelImplTests: XCTestCase {
         )
         
         // Then
-        // Then
         if let observerResult = observer.events.first,
            let result = observerResult.value.element {
             XCTAssertEqual(result, ErrorAlertMessage.client)


### PR DESCRIPTION
## ⭐️ Issue Number

- #387 

## 🚩 Summary

- NewStoreRequestViewModelImpl 테스트 코드를 작성한다.

![image](https://github.com/Korea-Certified-Store/iOS/assets/62226667/e7875650-2dbd-4990-93f4-ca8dc9305a00)

## 🛠️ Technical Concerns

### RxTest

이 전의 테스트들과는 다르게 ViewModel을 테스트 하기 위해서는 input값을 주고 그에 대한 결과값을 방출하기 전에 Output 옵저버들을 구독해야 했다.
이를 위해서 TestScheduler를 생성하고 테스트 하려는 Output의 값을 미리 subscribe를 해준 뒤 테스트를 진행하였다.
```swift
  private var scheduler: TestScheduler!
  
  override func setUp() {
      scheduler = TestScheduler(initialClock: 0)
      disposeBag = DisposeBag()
  }
  
  func test_제목_칸이_빈칸인_채로_수정을_마친_경우() {
      // Given
      let observer = scheduler.createObserver(Void.self)
      newStoreRequestViewModel.titleWarningOutput
          .subscribe(observer)
          .disposed(by: disposeBag)
      
      // When
      newStoreRequestViewModel.action(input: .endEdit(text: constant.emptyTestText, inputCase: .title))
      
      // Then
      XCTAssertNotNil(observer.events.first)
  }
```

## 🙂 To Reviwer

- 문법으로 인해 들어간 Switch문의 Default 때문에 Coverage 100%가 나오지 않았습니다.. Default로 가게되면 break로 아무런 일이 일어나지 않아 따로 테스트를 진행하지 않았습니다. 감안하고 봐주시면 감사하겠습니다!