### PR TITLE
StoreUpdateRequestViewModelImpl 테스트

### DIFF
--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -23,12 +23,12 @@
 		592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */; };
 		592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */; };
-		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
-		592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */; };
-		592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */; };
-		592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */; };
 		592D0E142B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E162B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */; };
+		592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */; };
+		592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */; };
+		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
+		592D0E1E2B943B12003E90F9 /* StubFetchStoreIDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */; };
 		594376342B81F071005B97B2 /* UpdateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376332B81F071005B97B2 /* UpdateRequestDTO.swift */; };
 		594376362B8201FB005B97B2 /* StoreUpdateRequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */; };
 		594376382B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */; };
@@ -48,6 +48,10 @@
 		594376622B875EFB005B97B2 /* GetStoresRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376612B875EFB005B97B2 /* GetStoresRepository.swift */; };
 		594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594376942B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift */; };
 		594376972B8CF630005B97B2 /* FetchStoresSuccessWithZeroStore.json in Resources */ = {isa = PBXBuildFile; fileRef = 594376962B8CF630005B97B2 /* FetchStoresSuccessWithZeroStore.json */; };
+		59491D7D2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */; };
+		59491D802B9752510009E77F /* SpySetStoreIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */; };
+		59491D822B9753EF0009E77F /* StubFetchStoreIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */; };
+		59491D842B9755740009E77F /* StubStoreUpdateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */; };
 		59503A4A2B741F1E0006CF35 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 59503A492B741F1E0006CF35 /* Secret.xcconfig */; };
 		59503A4E2B751B0B0006CF35 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A4D2B751B0B0006CF35 /* SearchViewController.swift */; };
 		59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A512B751FCC0006CF35 /* SearchViewModel.swift */; };
@@ -272,12 +276,12 @@
 		592D0E0B2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDRepositoryImplTests.swift; sourceTree = "<group>"; };
 		592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySaveRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
-		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
-		592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDRepository.swift; sourceTree = "<group>"; };
-		592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
-		592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
 		592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySpyDeleteRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
+		592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDRepository.swift; sourceTree = "<group>"; };
 		594376332B81F071005B97B2 /* UpdateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRequestDTO.swift; sourceTree = "<group>"; };
 		594376352B8201FB005B97B2 /* StoreUpdateRequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepository.swift; sourceTree = "<group>"; };
 		594376372B820272005B97B2 /* StoreUpdateRequestRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -297,6 +301,10 @@
 		594376612B875EFB005B97B2 /* GetStoresRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStoresRepository.swift; sourceTree = "<group>"; };
 		594376942B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoresRepositoryImplTests.swift; sourceTree = "<group>"; };
 		594376962B8CF630005B97B2 /* FetchStoresSuccessWithZeroStore.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FetchStoresSuccessWithZeroStore.json; sourceTree = "<group>"; };
+		59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestViewModelImplTests.swift; sourceTree = "<group>"; };
+		59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySetStoreIDUseCase.swift; sourceTree = "<group>"; };
+		59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDUseCase.swift; sourceTree = "<group>"; };
+		59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubStoreUpdateRequestUseCase.swift; sourceTree = "<group>"; };
 		59503A492B741F1E0006CF35 /* Secret.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		59503A4D2B751B0B0006CF35 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		59503A512B751FCC0006CF35 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
@@ -578,6 +586,24 @@
 			path = RepositoryTest;
 			sourceTree = "<group>";
 		};
+		59491D7B2B9751210009E77F /* ViewModelTest */ = {
+			isa = PBXGroup;
+			children = (
+				59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */,
+			);
+			path = ViewModelTest;
+			sourceTree = "<group>";
+		};
+		59491D7E2B9752410009E77F /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */,
+				59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */,
+				59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */,
+			);
+			path = UseCase;
+			sourceTree = "<group>";
+		};
 		59503A4B2B751AEE0006CF35 /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -749,6 +775,7 @@
 		5977BE8B2B5966F900725C90 /* KCSUnitTest */ = {
 			isa = PBXGroup;
 			children = (
+				59491D7B2B9751210009E77F /* ViewModelTest */,
 				594376932B8C7E5C005B97B2 /* RepositoryTest */,
 				A826745A2B8C7AD7004710CB /* UseCaseTest */,
 				A826745F2B8C7AD7004710CB /* TestDouble */,
@@ -1099,6 +1126,7 @@
 		A826745F2B8C7AD7004710CB /* TestDouble */ = {
 			isa = PBXGroup;
 			children = (
+				59491D7E2B9752410009E77F /* UseCase */,
 				A82674602B8C7AD7004710CB /* Repository */,
 				A82674912B8CFD61004710CB /* MockServer */,
 				A82674892B8CF6DF004710CB /* Resource */,
@@ -1731,11 +1759,14 @@
 				A8EC5B162B90FE6C00D9182F /* PostNewStoreRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
 				59C030932B8E4E8900A1A6FB /* MockURLProtocol.swift in Sources */,
+				59491D842B9755740009E77F /* StubStoreUpdateRequestUseCase.swift in Sources */,
 				A8EC5B002B8F9B1D00D9182F /* StubFailureNetworkRepository.swift in Sources */,
 				A82674692B8C7AD7004710CB /* StubSuccessImageRepository.swift in Sources */,
 				A8EC5B0E2B90DC2000D9182F /* DeleteAllHistoryRepositoryImplTests.swift in Sources */,
 				A826746A2B8C7AD7004710CB /* StubFailureImageRepository.swift in Sources */,
 				A8EC5B282B94818F00D9182F /* SetStoreIDRepositoryImplTests.swift in Sources */,
+				59491D802B9752510009E77F /* SpySetStoreIDUseCase.swift in Sources */,
+				59491D822B9753EF0009E77F /* StubFetchStoreIDUseCase.swift in Sources */,
 				A8EC5B062B903C7A00D9182F /* FetchRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 				A82674652B8C7AD7004710CB /* CheckNetworkStatusUseCaseImplTests.swift in Sources */,
 				A8EC5B2A2B9483D600D9182F /* SpySetStoreIDRepository.swift in Sources */,
@@ -1744,6 +1775,7 @@
 				59C030972B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift in Sources */,
 				592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */,
 				592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */,
+				59491D7D2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift in Sources */,
 				A8EC5B0A2B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KCS/KCS.xcodeproj/project.pbxproj
+++ b/KCS/KCS.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */; };
 		592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */; };
 		592D0E142B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */; };
-		592D0E162B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */; };
+		592D0E162B94324E003E90F9 /* SpyDeleteRecentSearchHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E152B94324E003E90F9 /* SpyDeleteRecentSearchHistoryRepository.swift */; };
 		592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */; };
 		592D0E1A2B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */; };
 		592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */; };
@@ -51,7 +51,9 @@
 		59491D7D2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */; };
 		59491D802B9752510009E77F /* SpySetStoreIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */; };
 		59491D822B9753EF0009E77F /* StubFetchStoreIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */; };
-		59491D842B9755740009E77F /* StubStoreUpdateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */; };
+		59491D842B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D832B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift */; };
+		59491D862B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D852B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift */; };
+		59491D882B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59491D872B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift */; };
 		59503A4A2B741F1E0006CF35 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 59503A492B741F1E0006CF35 /* Secret.xcconfig */; };
 		59503A4E2B751B0B0006CF35 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A4D2B751B0B0006CF35 /* SearchViewController.swift */; };
 		59503A522B751FCC0006CF35 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59503A512B751FCC0006CF35 /* SearchViewModel.swift */; };
@@ -277,7 +279,7 @@
 		592D0E0F2B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySaveRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
 		592D0E132B9431A6003E90F9 /* DeleteRecentSearchHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRecentSearchHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
-		592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySpyDeleteRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
+		592D0E152B94324E003E90F9 /* SpyDeleteRecentSearchHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteRecentSearchHistoryRepository.swift; sourceTree = "<group>"; };
 		592D0E172B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllHistoryUseCaseImplTests.swift; sourceTree = "<group>"; };
 		592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDeleteAllHistoryRepository.swift; sourceTree = "<group>"; };
 		592D0E1B2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStoreIDUseCaseImplTests.swift; sourceTree = "<group>"; };
@@ -304,7 +306,9 @@
 		59491D7C2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateRequestViewModelImplTests.swift; sourceTree = "<group>"; };
 		59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySetStoreIDUseCase.swift; sourceTree = "<group>"; };
 		59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFetchStoreIDUseCase.swift; sourceTree = "<group>"; };
-		59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubStoreUpdateRequestUseCase.swift; sourceTree = "<group>"; };
+		59491D832B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSuccessStoreUpdateRequestUseCase.swift; sourceTree = "<group>"; };
+		59491D852B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailureStoreUpdateRequestUseCase.swift; sourceTree = "<group>"; };
+		59491D872B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFailureFetchStoreIDUseCase.swift; sourceTree = "<group>"; };
 		59503A492B741F1E0006CF35 /* Secret.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		59503A4D2B751B0B0006CF35 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		59503A512B751FCC0006CF35 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
@@ -599,7 +603,9 @@
 			children = (
 				59491D7F2B9752510009E77F /* SpySetStoreIDUseCase.swift */,
 				59491D812B9753EF0009E77F /* StubFetchStoreIDUseCase.swift */,
-				59491D832B9755740009E77F /* StubStoreUpdateRequestUseCase.swift */,
+				59491D872B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift */,
+				59491D832B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift */,
+				59491D852B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -1145,7 +1151,7 @@
 				592D0E112B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift */,
 				592D0E1D2B943B12003E90F9 /* StubFetchStoreIDRepository.swift */,
 				592D0E192B943823003E90F9 /* SpyDeleteAllHistoryRepository.swift */,
-				592D0E152B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift */,
+				592D0E152B94324E003E90F9 /* SpyDeleteRecentSearchHistoryRepository.swift */,
 				A8EC5B292B9483D600D9182F /* SpySetStoreIDRepository.swift */,
 			);
 			path = Repository;
@@ -1744,7 +1750,7 @@
 				A8EC5B222B943DB700D9182F /* SetStoreIDUseCaseImplTests.swift in Sources */,
 				592D0E122B9354ED003E90F9 /* SpySaveRecentSearchHistoryRepository.swift in Sources */,
 				592D0E0C2B91B2FC003E90F9 /* FetchStoreIDRepositoryImplTests.swift in Sources */,
-				592D0E162B94324E003E90F9 /* SpySpyDeleteRecentSearchHistoryRepository.swift in Sources */,
+				592D0E162B94324E003E90F9 /* SpyDeleteRecentSearchHistoryRepository.swift in Sources */,
 				592D0E062B91AC94003E90F9 /* StoreUpdateRequestRepositoryImplTests.swift in Sources */,
 				592D0E1C2B9439C0003E90F9 /* FetchStoreIDUseCaseImplTests.swift in Sources */,
 				A8EC5B012B8F9B1F00D9182F /* StubSuccessNetworkRepository.swift in Sources */,
@@ -1759,7 +1765,8 @@
 				A8EC5B162B90FE6C00D9182F /* PostNewStoreRepositoryImplTests.swift in Sources */,
 				594376952B8C7EAD005B97B2 /* FetchStoresRepositoryImplTests.swift in Sources */,
 				59C030932B8E4E8900A1A6FB /* MockURLProtocol.swift in Sources */,
-				59491D842B9755740009E77F /* StubStoreUpdateRequestUseCase.swift in Sources */,
+				59491D882B9785D20009E77F /* StubFailureFetchStoreIDUseCase.swift in Sources */,
+				59491D842B9755740009E77F /* StubSuccessStoreUpdateRequestUseCase.swift in Sources */,
 				A8EC5B002B8F9B1D00D9182F /* StubFailureNetworkRepository.swift in Sources */,
 				A82674692B8C7AD7004710CB /* StubSuccessImageRepository.swift in Sources */,
 				A8EC5B0E2B90DC2000D9182F /* DeleteAllHistoryRepositoryImplTests.swift in Sources */,
@@ -1774,6 +1781,7 @@
 				A8EC5B1E2B933ABA00D9182F /* GetStoreInformationUseCaseImplTests.swift in Sources */,
 				59C030972B8FAD0B00A1A6FB /* GetStoresRepositoryImplTests.swift in Sources */,
 				592D0E182B9437AA003E90F9 /* DeleteAllHistoryUseCaseImplTests.swift in Sources */,
+				59491D862B9785080009E77F /* StubFailureStoreUpdateRequestUseCase.swift in Sources */,
 				592D0E102B934FFA003E90F9 /* SaveRecentSearchHistoryUseCaseImplTests.swift in Sources */,
 				59491D7D2B97513A0009E77F /* StoreUpdateRequestViewModelImplTests.swift in Sources */,
 				A8EC5B0A2B90C43A00D9182F /* SaveRecentSearchHistoryRepositoryImplTests.swift in Sources */,

--- a/KCS/KCS/Data/Repository/SetStoreIDRepositoryImpl.swift
+++ b/KCS/KCS/Data/Repository/SetStoreIDRepositoryImpl.swift
@@ -11,7 +11,7 @@ struct SetStoreIDRepositoryImpl: SetStoreIDRepository {
     
     let storage: StoreIDStorage
     
-    func fetchStoreID(id: Int) {
+    func setStoreID(id: Int) {
         storage.storeID = id
     }
     

--- a/KCS/KCS/Domain/Interface/Repository/SetStoreIDRepository.swift
+++ b/KCS/KCS/Domain/Interface/Repository/SetStoreIDRepository.swift
@@ -11,6 +11,6 @@ protocol SetStoreIDRepository {
     
     var storage: StoreIDStorage { get }
     
-    func fetchStoreID(id: Int)
+    func setStoreID(id: Int)
     
 }

--- a/KCS/KCS/Domain/UseCase/SetStoreIDUseCaseImpl.swift
+++ b/KCS/KCS/Domain/UseCase/SetStoreIDUseCaseImpl.swift
@@ -12,7 +12,7 @@ struct SetStoreIDUseCaseImpl: SetStoreIDUseCase {
     let repository: SetStoreIDRepository
     
     func execute(id: Int) {
-        repository.fetchStoreID(id: id)
+        repository.setStoreID(id: id)
     }
     
 }

--- a/KCS/KCS/Presentation/Search/View/SearchViewController.swift
+++ b/KCS/KCS/Presentation/Search/View/SearchViewController.swift
@@ -212,7 +212,7 @@ final class SearchViewController: UIViewController {
         self.textObserver = textObserver
         
         super.init(nibName: nil, bundle: nil)
-        setup()
+        modalPresentationStyle = .fullScreen
     }
     
     required init?(coder: NSCoder) {
@@ -222,6 +222,7 @@ final class SearchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setup()
         addUIComponents()
         configureConstraints()
         bind()
@@ -248,7 +249,6 @@ private extension SearchViewController {
     
     func setup() {
         view.backgroundColor = .white
-        modalPresentationStyle = .fullScreen
     }
     
     func addUIComponents() {

--- a/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/View/StoreUpdateRequestViewController.swift
@@ -46,9 +46,7 @@ final class StoreUpdateRequestViewController: UIViewController {
     }()
     
     private lazy var customNavigationBar: UINavigationBar = {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let statusBarHeight = scene.windows.first?.safeAreaInsets.top else { return UINavigationBar() }
-        let navigationBar = UINavigationBar(frame: .init(x: 0, y: statusBarHeight, width: view.frame.width, height: statusBarHeight))
+        let navigationBar = UINavigationBar()
         navigationBar.isTranslucent = false
         navigationBar.backgroundColor = .white
 
@@ -228,8 +226,7 @@ final class StoreUpdateRequestViewController: UIViewController {
         self.viewModel = viewModel
         
         super.init(nibName: nil, bundle: nil)
-        
-        setup()
+        modalPresentationStyle = .fullScreen
     }
     
     required init?(coder: NSCoder) {
@@ -239,6 +236,8 @@ final class StoreUpdateRequestViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setup()
+        setNavigationBar()
         addUIComponents()
         configureConstraints()
         bind()
@@ -271,6 +270,11 @@ private extension StoreUpdateRequestViewController {
     }
     
     func configureConstraints() {
+        NSLayoutConstraint.activate([
+            typeHeaderLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            typeHeaderLabel.topAnchor.constraint(equalTo: customNavigationBar.bottomAnchor, constant: 35)
+        ])
+        
         NSLayoutConstraint.activate([
             typeHeaderLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
             typeHeaderLabel.topAnchor.constraint(equalTo: customNavigationBar.bottomAnchor, constant: 35)
@@ -316,9 +320,16 @@ private extension StoreUpdateRequestViewController {
         ])
     }
     
+    func setNavigationBar() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let statusBarHeight = scene.windows.first?.safeAreaInsets.top else {
+            return
+        }
+        customNavigationBar.frame = CGRect(x: 0, y: statusBarHeight, width: view.frame.width, height: statusBarHeight)
+    }
+    
     func setup() {
         view.backgroundColor = .white
-        modalPresentationStyle = .fullScreen
         setNormalUI()
     }
     

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -87,7 +87,7 @@ private extension StoreUpdateRequestViewModelImpl {
     }
     
     func completeButtonIsEnable(type: String, content: String) {
-        if type.isEmpty || content.isEmpty {
+        if type.isEmpty || content.isEmpty || content.count > 300 {
             completeButtonIsEnabledOutput.accept(false)
         } else {
             completeButtonIsEnabledOutput.accept(true)

--- a/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
+++ b/KCS/KCS/Presentation/StoreUpdateRequest/ViewModel/StoreUpdateRequestViewModelImpl.swift
@@ -110,8 +110,6 @@ private extension StoreUpdateRequestViewModelImpl {
             onError: { [weak self] error in
                 if let error = error as? ErrorAlertMessage {
                     self?.errorAlertOutput.accept(error)
-                } else {
-                    self?.errorAlertOutput.accept(.client)
                 }
             }
         )

--- a/KCS/KCSUnitTest/RepositoryTest/SetStoreIDRepositoryImplTests.swift
+++ b/KCS/KCSUnitTest/RepositoryTest/SetStoreIDRepositoryImplTests.swift
@@ -29,7 +29,7 @@ final class SetStoreIDRepositoryImplTests: XCTestCase {
         // Given initial state
         
         // When
-        setStoreIDRepository.fetchStoreID(id: constant.storeID)
+        setStoreIDRepository.setStoreID(id: constant.storeID)
         
         //Then
         XCTAssertEqual(setStoreIDRepository.storage.storeID, constant.storeID)

--- a/KCS/KCSUnitTest/TestDouble/Repository/SpyDeleteRecentSearchHistoryRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/SpyDeleteRecentSearchHistoryRepository.swift
@@ -1,5 +1,5 @@
 //
-//  SpySpyDeleteRecentSearchHistoryRepository.swift
+//  SpyDeleteRecentSearchHistoryRepository.swift
 //  KCSUnitTest
 //
 //  Created by 조성민 on 3/3/24.

--- a/KCS/KCSUnitTest/TestDouble/Repository/SpySetStoreIDRepository.swift
+++ b/KCS/KCSUnitTest/TestDouble/Repository/SpySetStoreIDRepository.swift
@@ -17,7 +17,7 @@ final class SpySetStoreIDRepository: SetStoreIDRepository {
         self.storage = storage
     }
     
-    func fetchStoreID(id: Int) {
+    func setStoreID(id: Int) {
         executeCount += 1
     }
     

--- a/KCS/KCSUnitTest/TestDouble/UseCase/SpySetStoreIDUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/SpySetStoreIDUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  SpySetStoreIDUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/5/24.
+//
+
+import Foundation
+@testable import KCS
+
+final class SpySetStoreIDUseCase: SetStoreIDUseCase {
+    
+    let repository: SetStoreIDRepository
+    var executeCount: Int = 0
+    
+    init(repository: SetStoreIDRepository = SetStoreIDRepositoryImpl(storage: StoreIDStorage())) {
+        self.repository = repository
+    }
+    
+    func execute(id: Int) {
+        executeCount += 1
+    }
+    
+}

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubFailureFetchStoreIDUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubFailureFetchStoreIDUseCase.swift
@@ -1,14 +1,14 @@
 //
-//  StubFetchStoreIDUseCase.swift
+//  StubFailureFetchStoreIDUseCase.swift
 //  KCSUnitTest
 //
-//  Created by 조성민 on 3/5/24.
+//  Created by 조성민 on 3/6/24.
 //
 
 import Foundation
 @testable import KCS
 
-struct StubSuccessFetchStoreIDUseCase: FetchStoreIDUseCase {
+struct StubFailureFetchStoreIDUseCase: FetchStoreIDUseCase {
     
     let repository: FetchStoreIDRepository
     
@@ -17,7 +17,7 @@ struct StubSuccessFetchStoreIDUseCase: FetchStoreIDUseCase {
     }
     
     func execute() -> Int? {
-        return StoreUpdateRequestViewModelImplTestsConstant.fetchStoreIDUseCaseResult
+        return nil
     }
     
 }

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubFailureStoreUpdateRequestUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubFailureStoreUpdateRequestUseCase.swift
@@ -1,27 +1,13 @@
 //
-//  StubStoreUpdateRequestUseCase.swift
+//  StubFailureStoreUpdateRequestUseCase.swift
 //  KCSUnitTest
 //
-//  Created by 조성민 on 3/5/24.
+//  Created by 조성민 on 3/6/24.
 //
 
 @testable import KCS
 import RxSwift
 import Alamofire
-
-struct StubSuccessStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
-    
-    let repository: StoreUpdateRequestRepository
-    
-    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
-        self.repository = repository
-    }
-    
-    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
-        return .just(())
-    }
-    
-}
 
 struct StubInternetFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
     
@@ -76,22 +62,3 @@ struct StubClientFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
     }
     
 }
-
-struct StubAlamofireFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
-    
-    let repository: StoreUpdateRequestRepository
-    
-    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
-        self.repository = repository
-    }
-    
-    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
-        return Observable.create { observer -> Disposable in
-            observer.onError(ErrorAlertMessage.client)
-            
-            return Disposables.create()
-        }
-    }
-    
-}
-

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubFetchStoreIDUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubFetchStoreIDUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  StubFetchStoreIDUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/5/24.
+//
+
+import Foundation
+@testable import KCS
+
+struct StubSuccessFetchStoreIDUseCase: FetchStoreIDUseCase {
+    
+    let repository: FetchStoreIDRepository
+    
+    init(repository: FetchStoreIDRepository = FetchStoreIDRepositoryImpl(storage: StoreIDStorage())) {
+        self.repository = repository
+    }
+    
+    func execute() -> Int? {
+        return StoreUpdateRequestViewModelImplTestsConstant.fetchStoreIDUseCaseResult
+    }
+    
+}
+
+struct StubFailureFetchStoreIDUseCase: FetchStoreIDUseCase {
+    
+    let repository: FetchStoreIDRepository
+    
+    init(repository: FetchStoreIDRepository = FetchStoreIDRepositoryImpl(storage: StoreIDStorage())) {
+        self.repository = repository
+    }
+    
+    func execute() -> Int? {
+        return nil
+    }
+    
+}

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubStoreUpdateRequestUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubStoreUpdateRequestUseCase.swift
@@ -1,0 +1,98 @@
+//
+//  StubStoreUpdateRequestUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/5/24.
+//
+
+import Foundation
+@testable import KCS
+import RxSwift
+import Alamofire
+
+struct StubSuccessStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return .just(())
+    }
+    
+}
+
+struct StubInternetFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(ErrorAlertMessage.internet)
+            
+            return Disposables.create()
+        }
+    }
+    
+}
+
+struct StubServerFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(ErrorAlertMessage.server)
+            
+            return Disposables.create()
+        }
+    }
+    
+}
+
+struct StubClientFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(ErrorAlertMessage.client)
+            
+            return Disposables.create()
+        }
+    }
+    
+}
+
+struct StubAlamofireFailureStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            observer.onError(ErrorAlertMessage.client)
+            
+            return Disposables.create()
+        }
+    }
+    
+}
+

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubStoreUpdateRequestUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubStoreUpdateRequestUseCase.swift
@@ -5,7 +5,6 @@
 //  Created by 조성민 on 3/5/24.
 //
 
-import Foundation
 @testable import KCS
 import RxSwift
 import Alamofire

--- a/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessStoreUpdateRequestUseCase.swift
+++ b/KCS/KCSUnitTest/TestDouble/UseCase/StubSuccessStoreUpdateRequestUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  StubSuccessStoreUpdateRequestUseCase.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/5/24.
+//
+
+@testable import KCS
+import RxSwift
+import Alamofire
+
+struct StubSuccessStoreUpdateRequestUseCase: StoreUpdateRequestUseCase {
+    
+    let repository: StoreUpdateRequestRepository
+    
+    init(repository: StoreUpdateRequestRepository = StoreUpdateRequestRepositoryImpl(session: Session.default)) {
+        self.repository = repository
+    }
+    
+    func execute(type: StoreUpdateRequestType, storeID: Int, content: String) -> Observable<Void> {
+        return .just(())
+    }
+    
+}

--- a/KCS/KCSUnitTest/ViewModelTest/StoreUpdateRequestViewModelImplTests.swift
+++ b/KCS/KCSUnitTest/ViewModelTest/StoreUpdateRequestViewModelImplTests.swift
@@ -1,0 +1,481 @@
+//
+//  StoreUpdateRequestViewModelImplTests.swift
+//  KCSUnitTest
+//
+//  Created by 조성민 on 3/5/24.
+//
+
+import XCTest
+@testable import KCS
+import RxSwift
+import RxTest
+
+struct StoreUpdateRequestViewModelImplTestsConstant {
+    
+    static let fetchStoreIDUseCaseResult: Int = 3
+    let dummyStoreID: Int = 1234
+    let spySetStoreIDUseCaseExecuteCountResult: Int = 1
+    let emptyString: String = ""
+    let typeFixString: String = "수정"
+    let typeDeleteString: String = "삭제"
+    let contentInputNormalString: String = "abc"
+    let contentInputOverLengthString: String = String.init(repeating: "a", count: 301)
+    
+}
+
+// action의 종류 : 6개
+
+final class StoreUpdateRequestViewModelImplTests: XCTestCase {
+
+    private var storeUpdateRequestViewModel: StoreUpdateRequestViewModelImpl!
+    private var stubSuccessStoreUpdateRequestUseCase: StubSuccessStoreUpdateRequestUseCase!
+    private var stubInternetFailureStoreUpdateRequestUseCase: StubInternetFailureStoreUpdateRequestUseCase!
+    private var stubServerFailureStoreUpdateRequestUseCase: StubServerFailureStoreUpdateRequestUseCase!
+    private var stubClientFailureStoreUpdateRequestUseCase: StubClientFailureStoreUpdateRequestUseCase!
+    private var stubSuccessFetchStoreIDUseCase: StubSuccessFetchStoreIDUseCase!
+    private var stubFailureFetchStoreIDUseCase: StubFailureFetchStoreIDUseCase!
+    private var spySetStoreIDUseCase: SpySetStoreIDUseCase!
+    
+    private var scheduler: TestScheduler!
+    private var disposeBag: DisposeBag!
+    private var dependency: StoreUpdateRequestDepenency!
+    private var constant: StoreUpdateRequestViewModelImplTestsConstant!
+    
+    override func setUp() {
+        scheduler = TestScheduler(initialClock: 0)
+        disposeBag = DisposeBag()
+        constant = StoreUpdateRequestViewModelImplTestsConstant()
+        stubSuccessStoreUpdateRequestUseCase = StubSuccessStoreUpdateRequestUseCase()
+        stubInternetFailureStoreUpdateRequestUseCase = StubInternetFailureStoreUpdateRequestUseCase()
+        stubServerFailureStoreUpdateRequestUseCase = StubServerFailureStoreUpdateRequestUseCase()
+        stubClientFailureStoreUpdateRequestUseCase = StubClientFailureStoreUpdateRequestUseCase()
+        stubSuccessFetchStoreIDUseCase = StubSuccessFetchStoreIDUseCase()
+        stubFailureFetchStoreIDUseCase = StubFailureFetchStoreIDUseCase()
+        spySetStoreIDUseCase = SpySetStoreIDUseCase()
+    }
+    
+    func test_setStoreID_호출_성공() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .setStoreID(id: constant.dummyStoreID))
+        
+        // Then
+        XCTAssertEqual(spySetStoreIDUseCase.executeCount, constant.spySetStoreIDUseCaseExecuteCountResult)
+    }
+    
+    func test_typeInput_비어있는_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let observer = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.typeWarningOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .typeInput(text: constant.emptyString))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_typeInput_수정을_선택한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let observer = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.typeEditEndOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .typeInput(text: constant.typeFixString))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_typeInput_삭제를_선택한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let observer = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.typeEditEndOutput
+            .subscribe(observer)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .typeInput(text: constant.typeDeleteString))
+        
+        // Then
+        XCTAssertNotNil(observer.events.first)
+    }
+    
+    func test_contentEndEditing_content가_비어있는_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentWarningObserver = scheduler.createObserver(Void.self)
+        let contentLengthWarningObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentWarningOutput
+            .subscribe(contentWarningObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthWarningOutput
+            .subscribe(contentLengthWarningObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentEndEditing(text: constant.emptyString))
+        
+        // Then
+        XCTAssertNotNil(contentWarningObserver.events.first)
+        XCTAssertNotNil(contentLengthWarningObserver.events.first)
+    }
+    
+    func test_contentEndEditing_content길이가_1이상_300이하인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentEditEndObserver = scheduler.createObserver(Void.self)
+        let contentLengthNormalObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentEditEndOutput
+            .subscribe(contentEditEndObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthNormalOutput
+            .subscribe(contentLengthNormalObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentEndEditing(text: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertNotNil(contentEditEndObserver.events.first)
+        XCTAssertNotNil(contentLengthNormalObserver.events.first)
+    }
+    
+    func test_contentEndEditing_content길이가_300초과인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentWarningObserver = scheduler.createObserver(Void.self)
+        let contentLengthWarningObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentWarningOutput
+            .subscribe(contentWarningObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthWarningOutput
+            .subscribe(contentLengthWarningObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentEndEditing(text: constant.contentInputOverLengthString))
+        
+        // Then
+        XCTAssertNotNil(contentWarningObserver.events.first)
+        XCTAssertNotNil(contentLengthWarningObserver.events.first)
+    }
+    
+    func test_contentWhileEditing_content가_비어있는_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentFillPlaceHolderObserver = scheduler.createObserver(Void.self)
+        let contentLengthWarningObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentFillPlaceHolder
+            .subscribe(contentFillPlaceHolderObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthWarningOutput
+            .subscribe(contentLengthWarningObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentWhileEditing(text: constant.emptyString))
+        
+        // Then
+        XCTAssertNotNil(contentFillPlaceHolderObserver.events.first)
+        XCTAssertNotNil(contentLengthWarningObserver.events.first)
+    }
+    
+    func test_contentWhileEditing_content길이가_1이상_300이하인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentErasePlaceHolderObserver = scheduler.createObserver(Void.self)
+        let contentLengthNormalOutputObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentErasePlaceHolder
+            .subscribe(contentErasePlaceHolderObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthNormalOutput
+            .subscribe(contentLengthNormalOutputObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentWhileEditing(text: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertNotNil(contentErasePlaceHolderObserver.events.first)
+        XCTAssertNotNil(contentLengthNormalOutputObserver.events.first)
+    }
+    
+    func test_contentWhileEditing_content길이가_300초과인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let contentErasePlaceHolderObserver = scheduler.createObserver(Void.self)
+        let contentLengthWarningObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.contentErasePlaceHolder
+            .subscribe(contentErasePlaceHolderObserver)
+            .disposed(by: disposeBag)
+        storeUpdateRequestViewModel.contentLengthWarningOutput
+            .subscribe(contentLengthWarningObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .contentWhileEditing(text: constant.contentInputOverLengthString))
+        
+        // Then
+        XCTAssertNotNil(contentErasePlaceHolderObserver.events.first)
+        XCTAssertNotNil(contentLengthWarningObserver.events.first)
+    }
+    
+    func test_completeButtonIsEnable_type이_비어있는_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let completeButtonIsEnabledObserver = scheduler.createObserver(Bool.self)
+        
+        storeUpdateRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(completeButtonIsEnabledObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .completeButtonIsEnable(type: constant.emptyString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(completeButtonIsEnabledObserver.events.first?.value.element, false)
+    }
+    
+    func test_completeButtonIsEnable_content가_비어있는_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let completeButtonIsEnabledObserver = scheduler.createObserver(Bool.self)
+        
+        storeUpdateRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(completeButtonIsEnabledObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .completeButtonIsEnable(type: constant.typeFixString, content: constant.emptyString))
+        
+        // Then
+        XCTAssertEqual(completeButtonIsEnabledObserver.events.first?.value.element, false)
+    }
+    
+    func test_completeButtonIsEnable_content_길이가_300초과인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let completeButtonIsEnabledObserver = scheduler.createObserver(Bool.self)
+        
+        storeUpdateRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(completeButtonIsEnabledObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .completeButtonIsEnable(type: constant.typeFixString, content: constant.contentInputOverLengthString))
+        
+        // Then
+        XCTAssertEqual(completeButtonIsEnabledObserver.events.first?.value.element, false)
+    }
+    
+    func test_completeButtonIsEnable_type이_있으며_content길이가_1이상_300이하인_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let completeButtonIsEnabledObserver = scheduler.createObserver(Bool.self)
+        
+        storeUpdateRequestViewModel.completeButtonIsEnabledOutput
+            .subscribe(completeButtonIsEnabledObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .completeButtonIsEnable(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(completeButtonIsEnabledObserver.events.first?.value.element, true)
+    }
+    
+    func test_storeUpdateRequest_fetchStoreID_실패한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubFailureFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let errorAlertObserver = scheduler.createObserver(ErrorAlertMessage.self)
+        
+        storeUpdateRequestViewModel.errorAlertOutput
+            .subscribe(errorAlertObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .storeUpdateRequest(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(errorAlertObserver.events.first?.value.element, .client)
+    }
+    
+    func test_storeUpdateRequest_fetchStoreID_성공후_storeUpdateRequest_Internet_에러로_실패한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubInternetFailureStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let errorAlertObserver = scheduler.createObserver(ErrorAlertMessage.self)
+        
+        storeUpdateRequestViewModel.errorAlertOutput
+            .subscribe(errorAlertObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .storeUpdateRequest(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(errorAlertObserver.events.first?.value.element, .internet)
+    }
+    
+    func test_storeUpdateRequest_fetchStoreID_성공후_storeUpdateRequest_Server_에러로_실패한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubServerFailureStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let errorAlertObserver = scheduler.createObserver(ErrorAlertMessage.self)
+        
+        storeUpdateRequestViewModel.errorAlertOutput
+            .subscribe(errorAlertObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .storeUpdateRequest(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(errorAlertObserver.events.first?.value.element, .server)
+    }
+    
+    func test_storeUpdateRequest_fetchStoreID_성공후_storeUpdateRequest_Client_에러로_실패한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubClientFailureStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let errorAlertObserver = scheduler.createObserver(ErrorAlertMessage.self)
+        
+        storeUpdateRequestViewModel.errorAlertOutput
+            .subscribe(errorAlertObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .storeUpdateRequest(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertEqual(errorAlertObserver.events.first?.value.element, .client)
+    }
+    
+    func test_storeUpdateRequest_fetchStoreID_성공후_storeUpdateRequest_성공한_경우() {
+        // Given
+        dependency = StoreUpdateRequestDepenency(
+            storeUpdateRequestUseCase: stubSuccessStoreUpdateRequestUseCase,
+            fetchStoreIDUseCase: stubSuccessFetchStoreIDUseCase,
+            setStoreIDUseCase: spySetStoreIDUseCase
+        )
+        storeUpdateRequestViewModel = StoreUpdateRequestViewModelImpl(dependency: dependency)
+        let completeRequestObserver = scheduler.createObserver(Void.self)
+        
+        storeUpdateRequestViewModel.completeRequestOutput
+            .subscribe(completeRequestObserver)
+            .disposed(by: disposeBag)
+        
+        // When
+        storeUpdateRequestViewModel.action(input: .storeUpdateRequest(type: constant.typeFixString, content: constant.contentInputNormalString))
+        
+        // Then
+        XCTAssertNotNil(completeRequestObserver.events.first)
+    }
+    
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #375

## 🚩 Summary

- 잘못된 함수 이름 변경 (Fetch -> Set)
- init과 ViewDidLoad 싱크 문제 해결 (네비게이션바가 없어지는 현상 제거)
- 완료 버튼 활성화 조건 수정
- StoreUpdateRequestViewModelImpl 테스트

<img width="1424" alt="image" src="https://github.com/Korea-Certified-Store/iOS/assets/128480641/be3bb5af-34aa-4117-9023-308b26a88de8">


## 🛠️ Technical Concerns

### init과 ViewDidLoad

init에서 UI와 관련된 코드를 작성하는 순간 ViewDidLoad가 호출되는 것을 이제서야 알게 됐다.
UI와 관련된 코드는 ViewDidLoad로 옮기고 기본적인 설정만 init에서 해줘야 한다.
